### PR TITLE
Ethernetprovider_add: Adding reply_echo_cmd kwarg to ethernet_provider.py

### DIFF
--- a/dragonfly/implementations/ethernet_provider.py
+++ b/dragonfly/implementations/ethernet_provider.py
@@ -69,6 +69,8 @@ class EthernetProvider(Provider):
                     command += self.command_terminator
                 self.socket.send(command)
                 data = self.get()
+                import ipdb
+                ipdb.set_trace()
                 if data.startswith(command):
                     data = data.rsplit(self.command_terminator,1)[1]
                 logger.debug('sync: {} -> {}'.format(repr(command),repr(data)))

--- a/dragonfly/implementations/ethernet_provider.py
+++ b/dragonfly/implementations/ethernet_provider.py
@@ -72,9 +72,8 @@ class EthernetProvider(Provider):
                     command += self.command_terminator
                 self.socket.send(command)
                 data = self.get()
-                logger.debug('sync: {} -> {}'.format(repr(command),repr(data)))
                 # Edit starts here - Luis Saldana
-                if (self.command_terminator and data.startswith(self.command_terminator)):
+                if data.startswith(self.command_terminator):
                     data = data.rsplit(self.command_terminator,1)[1]
                 # Edit ends here - Luis Saldana
                 logger.debug('sync: {} -> {}'.format(repr(command),repr(data)))

--- a/dragonfly/implementations/ethernet_provider.py
+++ b/dragonfly/implementations/ethernet_provider.py
@@ -76,6 +76,8 @@ class EthernetProvider(Provider):
                 if data.startswith(self.command_terminator):
                     data = data.rsplit(self.command_terminator,1)[1]
                 # Edit ends here - Luis Saldana
+                import ipdb
+                ipdb.set_trace()
                 logger.debug('sync: {} -> {}'.format(repr(command),repr(data)))
                 all_data.append(data)
         finally:

--- a/dragonfly/implementations/ethernet_provider.py
+++ b/dragonfly/implementations/ethernet_provider.py
@@ -1,5 +1,3 @@
-
-
 from __future__ import absolute_import
 import socket
 import threading

--- a/dragonfly/implementations/ethernet_provider.py
+++ b/dragonfly/implementations/ethernet_provider.py
@@ -72,6 +72,10 @@ class EthernetProvider(Provider):
                     command += self.command_terminator
                 self.socket.send(command)
                 data = self.get()
+                # Edit starts here - Luis
+                if (self.command_terminator and data.startswith(self.command_terminator)):
+                    data = data.rsplit(self.command_terminator,1)[1]
+                # Edit ends here - Luis
                 logger.debug('sync: {} -> {}'.format(repr(command),repr(data)))
                 all_data.append(data)
         finally:

--- a/dragonfly/implementations/ethernet_provider.py
+++ b/dragonfly/implementations/ethernet_provider.py
@@ -69,10 +69,8 @@ class EthernetProvider(Provider):
                     command += self.command_terminator
                 self.socket.send(command)
                 data = self.get()
-                import ipdb
-                ipdb.set_trace()
                 if data.startswith(command):
-                    data = data.rsplit(self.command_terminator,1)[1]
+                    data = data[data.startswith(command) and len(command):]
                 logger.debug('sync: {} -> {}'.format(repr(command),repr(data)))
                 all_data.append(data)
         finally:

--- a/dragonfly/implementations/ethernet_provider.py
+++ b/dragonfly/implementations/ethernet_provider.py
@@ -72,10 +72,10 @@ class EthernetProvider(Provider):
                     command += self.command_terminator
                 self.socket.send(command)
                 data = self.get()
-                # Edit starts here - Luis
+                # Edit starts here - Luis Saldana
                 if (self.command_terminator and data.startswith(self.command_terminator)):
                     data = data.rsplit(self.command_terminator,1)[1]
-                # Edit ends here - Luis
+                # Edit ends here - Luis Saldana
                 logger.debug('sync: {} -> {}'.format(repr(command),repr(data)))
                 all_data.append(data)
         finally:

--- a/dragonfly/implementations/ethernet_provider.py
+++ b/dragonfly/implementations/ethernet_provider.py
@@ -72,12 +72,12 @@ class EthernetProvider(Provider):
                     command += self.command_terminator
                 self.socket.send(command)
                 data = self.get()
+                import ipdb
+                ipdb.set_trace()
                 # Edit starts here - Luis Saldana
                 if data.startswith(self.command_terminator):
                     data = data.rsplit(self.command_terminator,1)[1]
                 # Edit ends here - Luis Saldana
-                import ipdb
-                ipdb.set_trace()
                 logger.debug('sync: {} -> {}'.format(repr(command),repr(data)))
                 all_data.append(data)
         finally:

--- a/dragonfly/implementations/ethernet_provider.py
+++ b/dragonfly/implementations/ethernet_provider.py
@@ -28,6 +28,7 @@ class EthernetProvider(Provider):
         socket_info (tuple): (<network_address_as_str>, <port_as_int>)
         response_terminator (str||None): string to rstrip() from responses
         command_terminator (str||None): string to append to commands
+        reply_echo_cmd (bool): set to true if command+command_terminator are present in reply
         '''
         Provider.__init__(self, **kwargs)
         self.alock = threading.Lock()

--- a/dragonfly/implementations/ethernet_provider.py
+++ b/dragonfly/implementations/ethernet_provider.py
@@ -20,6 +20,7 @@ class EthernetProvider(Provider):
                  socket_info=("localhost",1234),
                  response_terminator = None,
                  command_terminator = None,
+                 reply_echo_cmd = False,
                  **kwargs
                  ):
         '''
@@ -69,7 +70,9 @@ class EthernetProvider(Provider):
                     command += self.command_terminator
                 self.socket.send(command)
                 data = self.get()
-                if data.startswith(command):
+                import ipdb
+                ipdb.set_trace()
+                if (data.startswith(command) and self.reply_echo_cmd):
                     data = data[data.startswith(command) and len(command):]
                 logger.debug('sync: {} -> {}'.format(repr(command),repr(data)))
                 all_data.append(data)

--- a/dragonfly/implementations/ethernet_provider.py
+++ b/dragonfly/implementations/ethernet_provider.py
@@ -72,6 +72,7 @@ class EthernetProvider(Provider):
                     command += self.command_terminator
                 self.socket.send(command)
                 data = self.get()
+                logger.debug('sync: {} -> {}'.format(repr(command),repr(data)))
                 # Edit starts here - Luis Saldana
                 if (self.command_terminator and data.startswith(self.command_terminator)):
                     data = data.rsplit(self.command_terminator,1)[1]

--- a/dragonfly/implementations/ethernet_provider.py
+++ b/dragonfly/implementations/ethernet_provider.py
@@ -69,10 +69,8 @@ class EthernetProvider(Provider):
                     command += self.command_terminator
                 self.socket.send(command)
                 data = self.get()
-                # Edit starts here - Luis Saldana
                 if data.startswith(command):
                     data = data.rsplit(self.command_terminator,1)[1]
-                # Edit ends here - Luis Saldana
                 logger.debug('sync: {} -> {}'.format(repr(command),repr(data)))
                 all_data.append(data)
         finally:

--- a/dragonfly/implementations/ethernet_provider.py
+++ b/dragonfly/implementations/ethernet_provider.py
@@ -75,8 +75,6 @@ class EthernetProvider(Provider):
                 if data.startswith(command):
                     data = data.rsplit(self.command_terminator,1)[1]
                 # Edit ends here - Luis Saldana
-                import ipdb
-                ipdb.set_trace()
                 logger.debug('sync: {} -> {}'.format(repr(command),repr(data)))
                 all_data.append(data)
         finally:

--- a/dragonfly/implementations/ethernet_provider.py
+++ b/dragonfly/implementations/ethernet_provider.py
@@ -65,19 +65,18 @@ class EthernetProvider(Provider):
         all_data = []
         self.alock.acquire()
         try:
-            
             for command in commands:
                 logger.debug('sending: {}'.format(repr(command)))
                 if self.command_terminator is not None:
                     command += self.command_terminator
                 self.socket.send(command)
                 data = self.get()
-                import ipdb
-                ipdb.set_trace()
                 # Edit starts here - Luis Saldana
-                if data.startswith(self.command_terminator):
+                if data.startswith(command):
                     data = data.rsplit(self.command_terminator,1)[1]
                 # Edit ends here - Luis Saldana
+                import ipdb
+                ipdb.set_trace()
                 logger.debug('sync: {} -> {}'.format(repr(command),repr(data)))
                 all_data.append(data)
         finally:

--- a/dragonfly/implementations/ethernet_provider.py
+++ b/dragonfly/implementations/ethernet_provider.py
@@ -36,6 +36,7 @@ class EthernetProvider(Provider):
         self.socket = socket.socket()
         self.response_terminator = response_terminator
         self.command_terminator = command_terminator
+        self.reply_echo_cmd = reply_echo_cmd
         if type(self.socket_info) is str:
             import re
             re_str = "\([\"'](\S+)[\"'], ?(\d+)\)"
@@ -70,8 +71,6 @@ class EthernetProvider(Provider):
                     command += self.command_terminator
                 self.socket.send(command)
                 data = self.get()
-                import ipdb
-                ipdb.set_trace()
                 if (data.startswith(command) and self.reply_echo_cmd):
                     data = data[data.startswith(command) and len(command):]
                 logger.debug('sync: {} -> {}'.format(repr(command),repr(data)))


### PR DESCRIPTION
Added a new kwarg called reply_echo_cmd which is initialized to False. If the ethernet provider sends response back with original command + response terminator, this removes the first bit and returns only the response from the machine. If your machine has this feature, set reply_echo_cmd to True in your config file.