### PR TITLE
Feature/muxer get spime conf string add

### DIFF
--- a/dragonfly/implementations/prologix.py
+++ b/dragonfly/implementations/prologix.py
@@ -122,7 +122,7 @@ class MuxerGetSpime(SimpleSCPIGetSpime):
     def __init__(self, ch_number, conf_str = None, **kwargs):
 	if conf_str is None:
 		logger.debug('no configuration string given for endpoint')
-	else	
+	else:	
 		self.conf_str = conf_str        
 	self.base_str = "DATA:LAST? (@{})"
         self.ch_number = ch_number

--- a/dragonfly/implementations/prologix.py
+++ b/dragonfly/implementations/prologix.py
@@ -119,8 +119,12 @@ def cernox_calibration(resistance, serial_number):
 
 
 class MuxerGetSpime(SimpleSCPIGetSpime):
-    def __init__(self, ch_number, **kwargs):
-        self.base_str = "DATA:LAST? (@{})"
+    def __init__(self, ch_number, conf_str = None, **kwargs):
+	if conf_str is None:
+		logger.debug('no configuration string given for endpoint')
+	else	
+		self.conf_str = conf_str        
+	self.base_str = "DATA:LAST? (@{})"
         self.ch_number = ch_number
         SimpleSCPIGetSpime.__init__(self, base_str=self.base_str, **kwargs)
         self.get_value = self.on_get

--- a/dragonfly/implementations/prologix.py
+++ b/dragonfly/implementations/prologix.py
@@ -120,10 +120,7 @@ def cernox_calibration(resistance, serial_number):
 
 class MuxerGetSpime(SimpleSCPIGetSpime):
     def __init__(self, ch_number, conf_str = None, **kwargs):
-	if conf_str is None:
-		logger.debug('no configuration string given for endpoint')
-	else:	
-		self.conf_str = conf_str        
+	self.conf_str = conf_str        
 	self.base_str = "DATA:LAST? (@{})"
         self.ch_number = ch_number
         SimpleSCPIGetSpime.__init__(self, base_str=self.base_str, **kwargs)


### PR DESCRIPTION
Added conf_str as an initializing parameter for the MuxerGetSpime class, default is None. Purpose is for endpoints to internally store its configuration string. Tested and works well.