### PR TITLE
Feature/daq provider cleaning

### DIFF
--- a/dragonfly/implementations/daq_run_interface.py
+++ b/dragonfly/implementations/daq_run_interface.py
@@ -36,7 +36,6 @@ class DAQProvider(core.Provider):
                  snapshot_target_items=None,
                  metadata_state_target='',
                  metadata_target='',
-                 debug_mode_without_snapshot_broadcast=False,
                  **kwargs):
         '''
         daq_name (str): name of the DAQ (used with the run table and in metadata)

--- a/dragonfly/implementations/sql_snapshot.py
+++ b/dragonfly/implementations/sql_snapshot.py
@@ -75,7 +75,7 @@ class SQLSnapshot(SQLTable):
             logger.error('{}; in executing SQLAlchemy select statement'.format(dripline_error.message))
             return
         if not query_return:
-            logger.warning('no entries found between "{}" and "{}"'.format(start_timestamp,end_timestamp))
+            logger.critical('no entries found in database between "{}" and "{}" hence producing empty snapshot'.format(start_timestamp,end_timestamp))
 
         # Counting how many times each endpoint is present
         endpoint_name_raw = []
@@ -143,7 +143,7 @@ class SQLSnapshot(SQLTable):
                 logger.error('{}; in executing SQLAlchemy select statement to obtain endpoint_id for endpoint "{}"'.format(dripline_error.message,name))
                 return
             if not query_return:
-                logger.error('endpoint with name "{}" not found in database'.format(name))
+                logger.critical('endpoint with name "{}" not found in database hence failed to take snapshot of its value; might need it to add to the db'.format(name))
                 continue
             else:
                 ept_id = query_return[0]['endpoint_id']
@@ -156,7 +156,7 @@ class SQLSnapshot(SQLTable):
                 logger.error('{}; in executing SQLAlchemy select statement for endpoint "{}"'.format(dripline_error.message,name))
                 return
             if not query_return:
-                logger.error('no records found before "{}" for endpoint "{}" in database'.format(timestamp,name))
+                logger.critical('no records found before "{}" for endpoint "{}" in database hence not recording its snapshot'.format(timestamp,name))
                 continue
             else:
                 val_raw_dict[name] = {'timestamp' : query_return[0]['timestamp'].strftime(constants.TIME_FORMAT),


### PR DESCRIPTION
- Removed debug flags from DAQProvider which are not needed now that we have a working virtual system in insectarium. The <code>determine_RF_ROI</code> method in DAQProvider now broadcasts a logger.warning message noting that this method is skipped unless initiating an object with a subclass (which as of now is only RSAAcquisitionInterface)

- We now generate one single snapshot file instead of two. This file contains the latest and the logs output of SQLSnapshot. Its content will be sent to mdreceiver at the end of run.  

- Changed some logging levels to critical in SQLSnapshot. These are related to it not being able to find an endpoint with a given name or any entries in the db between two timestamps. 

- All tested in insectarium/feature/DAQProviderCleaning and working well.