### PR TITLE
Bug/database issues

### DIFF
--- a/dragonfly/implementations/daq_db_interface.py
+++ b/dragonfly/implementations/daq_db_interface.py
@@ -131,8 +131,11 @@ class InsertDBEndpoint(Endpoint):
         # build the insert dict
         this_insert = self._default_insert_dict.copy()
         this_insert.update(kwargs)
-        return_vals = self.provider._insert_with_return(self._table_name,
+        try:
+            return_vals = self.provider._insert_with_return(self._table_name,
                                                         this_insert,
                                                         self._return_names,
                                                        )
+        except Exception as err:
+            logger.critical('got an error when attempting to insert into the db: {}'.format(str(err)))
         return return_vals

--- a/dragonfly/implementations/daq_db_interface.py
+++ b/dragonfly/implementations/daq_db_interface.py
@@ -79,6 +79,7 @@ class RunDBInterface(Provider):
         except Exception as err:
             db_errs = ('(psycopg2.IntegrityError)','(psycopg2.DataError)')
             if str(err).startswith(db_errs):
+                logger.error('failed to make an SQL insert and receive return:\n{}'.format(str(err)))
                 raise DriplineDatabaseError(str(err))
             else:
                 logger.warning('unknown error while working with sql')
@@ -131,11 +132,8 @@ class InsertDBEndpoint(Endpoint):
         # build the insert dict
         this_insert = self._default_insert_dict.copy()
         this_insert.update(kwargs)
-        try:
-            return_vals = self.provider._insert_with_return(self._table_name,
+        return_vals = self.provider._insert_with_return(self._table_name,
                                                         this_insert,
                                                         self._return_names,
                                                        )
-        except Exception as err:
-            logger.critical('got an error when attempting to insert into the db: {}'.format(str(err)))
         return return_vals

--- a/dragonfly/implementations/daq_db_interface.py
+++ b/dragonfly/implementations/daq_db_interface.py
@@ -77,7 +77,8 @@ class RunDBInterface(Provider):
             else:
                 return_values = []
         except Exception as err:
-            if str(err).startswith('(psycopg2.IntegrityError)'):
+            db_errs = ('(psycopg2.IntegrityError)','(psycopg2.DataError)')
+            if str(err).startswith(db_errs):
                 raise DriplineDatabaseError(str(err))
             else:
                 logger.warning('unknown error while working with sql')

--- a/dragonfly/implementations/daq_db_interface.py
+++ b/dragonfly/implementations/daq_db_interface.py
@@ -79,7 +79,7 @@ class RunDBInterface(Provider):
         except Exception as err:
             db_errs = ('(psycopg2.IntegrityError)','(psycopg2.DataError)')
             if str(err).startswith(db_errs):
-                logger.error('failed to make an SQL insert and receive return:\n{}'.format(str(err)))
+                logger.error('failed to make an SQL insert and receive return. error:\n{}'.format(str(err)))
                 raise DriplineDatabaseError(str(err))
             else:
                 logger.warning('unknown error while working with sql')

--- a/dragonfly/implementations/daq_run_interface.py
+++ b/dragonfly/implementations/daq_run_interface.py
@@ -114,13 +114,10 @@ class DAQProvider(core.Provider):
     def start_run(self, run_name):
         '''
         '''
-        try:
-            logger.debug('self._run_name before setting is: {}'.format(self._run_name))
-            self.run_name = run_name
-            logger.debug('self._run_name after setting is: {}'.format(self._run_name))
-        except Exception as err:
-            logger.critical('all internal run procedures will be squashed')
-            raise
+        self.run_name = run_name
+        if self._run_name is None:
+            logger.critical('run_name is not present; all internal run procedures will be squashed')
+            raise core.exceptions.DriplineValueError('<{}> instance <{}> requires a value for "{}" to initialize run and procedures'.format(self.__class__.__name__, self.name, '_run_name'))
         self._run_meta = {'DAQ': self.daq_name,
                          }
         self._run_snapshot = {'LATEST':{},'LOGS':{}}

--- a/dragonfly/implementations/daq_run_interface.py
+++ b/dragonfly/implementations/daq_run_interface.py
@@ -76,6 +76,7 @@ class DAQProvider(core.Provider):
         self._stop_handle = None
         self._run_name = None
         self.run_id = None
+        self._start_time = None
         self._acquisition_count = None
 
     @property
@@ -85,9 +86,12 @@ class DAQProvider(core.Provider):
     def run_name(self, value):
         self._run_name = value
         self._acquisition_count = 0
-        result = self.provider.cmd(self.run_table_endpoint, 'do_insert', payload={'run_name':value})
-        self.run_id = result['run_id']
-        self._start_time = result['start_timestamp']
+        try:
+            result = self.provider.cmd(self.run_table_endpoint, 'do_insert', payload={'run_name':value})
+            self.run_id = result['run_id']
+            self._start_time = result['start_timestamp']
+        except core.exceptions.DriplineDatabaseError as dripline_error:
+            logger.error('failed to insert run_name to the db and obtain run_id and start_timestamp:\n{}'.format(dripline_error.message))
 
     def end_run(self):
         self._do_postrun_gets()

--- a/dragonfly/implementations/daq_run_interface.py
+++ b/dragonfly/implementations/daq_run_interface.py
@@ -142,7 +142,7 @@ class DAQProvider(core.Provider):
             self._run_snapshot['LOGS'].update(these_snaps)
 
     def determine_RF_ROI(self):
-        raise core.exceptions.DriplineMethodNotSupportedError('subclass must implement RF ROI determination')
+        logger.warning('subclass must implement RF ROI determination; skipped')
 
     def _send_metadata(self):
         '''

--- a/dragonfly/implementations/daq_run_interface.py
+++ b/dragonfly/implementations/daq_run_interface.py
@@ -99,7 +99,6 @@ class DAQProvider(core.Provider):
                 self._stop_handle = None
                 self._run_name = None
                 self._run_id = None
-            result = None
                 
     def end_run(self):
         self._do_postrun_gets()
@@ -116,7 +115,7 @@ class DAQProvider(core.Provider):
         '''
         '''
         self._run_name = run_name
-        if not self._run_name:
+        if self._run_name is None:
             raise core.exceptions.DriplineValueError('run_name cannot be empty; all run internal procedures have been squashed')
         self._run_meta = {'DAQ': self.daq_name,
                          }

--- a/dragonfly/implementations/daq_run_interface.py
+++ b/dragonfly/implementations/daq_run_interface.py
@@ -95,7 +95,7 @@ class DAQProvider(core.Provider):
             # end the run
             if self._stop_handle is not None:
                 self.service._connection.remove_timeout(self._stop_handle)
-                logger.critical('run <{}> was not started')
+                logger.critical('run <{}> was not started'.format(value))
                 self._stop_handle = None
                 self._run_name = None
                 self.run_id = None
@@ -115,9 +115,11 @@ class DAQProvider(core.Provider):
         '''
         '''
         try:
+            logger.debug('self._run_name before setting is: {}'.format(self._run_name))
             self.run_name = run_name
+            logger.debug('self._run_name after setting is: {}'.format(self._run_name))
         except Exception as err:
-            logger.critical('all run internal procedures will be squashed')
+            logger.critical('all internal run procedures will be squashed')
             raise
         self._run_meta = {'DAQ': self.daq_name,
                          }

--- a/dragonfly/implementations/daq_run_interface.py
+++ b/dragonfly/implementations/daq_run_interface.py
@@ -90,12 +90,12 @@ class DAQProvider(core.Provider):
             result = self.provider.cmd(self.run_table_endpoint, 'do_insert', payload={'run_name':value})
             self._run_id = result['run_id']
             self._start_time = result['start_timestamp']
-        except core.exceptions.DriplineDatabaseError as dripline_error:
-            logger.critical('failed to insert run_name to the db, obtain run_id, and start_timestamp. error:\n{}'.format(dripline_error.message))
+        except Exception as err:
+            logger.critical('failed to insert run_name to the db, obtain run_id, and start_timestamp. error:\n{}'.format(str(err)))
             # end the run
             if self._stop_handle is not None:
                 self.service._connection.remove_timeout(self._stop_handle)
-                logger.critical('run <{}> was ended prematurely and not started')
+                logger.critical('run <{}> was not started')
                 self._stop_handle = None
                 self._run_name = None
                 self._run_id = None
@@ -114,9 +114,11 @@ class DAQProvider(core.Provider):
     def start_run(self, run_name):
         '''
         '''
-        self._run_name = run_name
-        if self._run_name is None:
-            raise core.exceptions.DriplineValueError('run_name cannot be empty; all run internal procedures have been squashed')
+        try:
+            self._run_name = run_name
+        except Exception as err:
+            logger.critical('all run internal procedures will be squashed')
+            raise
         self._run_meta = {'DAQ': self.daq_name,
                          }
         self._run_snapshot = {'LATEST':{},'LOGS':{}}

--- a/dragonfly/implementations/sensor_logger.py
+++ b/dragonfly/implementations/sensor_logger.py
@@ -26,6 +26,8 @@ class SensorLogger(Gogol, PostgreSQLInterface):
         sensor_type_map_table (str): name of the child endpoint of this instance which provides access to the endpoint_id_map, which stores the sensor type
         data_tables_dict (dict): dictionary mapping types (in the sensor_type_map_table) to child endpoints of this instance which provide access to the data_table for that type
         '''
+        # listen to sensor_value alerts channel
+        kwargs.update({'exchange':'alerts','keys':['sensor_value.#']})
         Gogol.__init__(self, **kwargs)
         PostgreSQLInterface.__init__(self, **kwargs)
 

--- a/dragonfly/implementations/sensor_logger.py
+++ b/dragonfly/implementations/sensor_logger.py
@@ -44,7 +44,6 @@ class SensorLogger(Gogol, PostgreSQLInterface):
         if '.' in basic_deliver.routing_key:
             logger.debug('basic_deliver.routing_key is: {}'.format(basic_deliver.routing_key))
             re_out = re.match(r'sensor_value.(?P<from>\S+)', basic_deliver.routing_key)
-            logger.debug('re_out is: {}'.format(re_out))
             logger.debug('re_out.groupdict() is: {}'.format(re_out.groupdict()))
             sensor_name = re_out.groupdict()['from']
         # note that the following is deprecated in dripline 2.x, retained for compatibility
@@ -53,7 +52,6 @@ class SensorLogger(Gogol, PostgreSQLInterface):
 
         ### Get the type and table for the sensor
         this_type = None
-<<<<<<< HEAD
         this_table = self.endpoints[self._sensor_type_map_table]
         this_type = this_table.do_select(return_cols=['type'],
                                          where_eq_dict={'endpoint_name':sensor_name},
@@ -61,22 +59,19 @@ class SensorLogger(Gogol, PostgreSQLInterface):
         if not this_type[1]:
             logger.critical('endpoint with name "{}" was not found in database hence failed to log its value; might need it to add to the db'.format(sensor_name))
         else:
-=======
-        if sensor_name not in self._sensor_types.keys():
             this_table = self.endpoints[self._sensor_type_map_table]
             this_type = this_table.do_select(return_cols=['type'],
                                              where_eq_dict={'endpoint_name':sensor_name},
                                             )
->>>>>>> develop
             self._sensor_types[sensor_name] = this_type[1][0][0]
-        this_data_table = self.endpoints[self._data_tables[self._sensor_types[sensor_name]]]
+            this_data_table = self.endpoints[self._data_tables[self._sensor_types[sensor_name]]]
 
-        ### Log the sensor value
-        insert_data = {'endpoint_name': sensor_name,
-                       'timestamp': message['timestamp'],
-                      }
-        for key in ['value_raw', 'value_cal', 'memo']:
-            if key in message.payload:
-                insert_data[key] = message.payload[key]
-        this_data_table.do_insert(**insert_data)
-        logger.info('value logged for <{}>'.format(sensor_name))
+            ### Log the sensor value
+            insert_data = {'endpoint_name': sensor_name,
+                           'timestamp': message['timestamp'],
+                          }
+            for key in ['value_raw', 'value_cal', 'memo']:
+                if key in message.payload:
+                    insert_data[key] = message.payload[key]
+            this_data_table.do_insert(**insert_data)
+            logger.info('value logged for <{}>'.format(sensor_name))

--- a/dragonfly/implementations/sensor_logger.py
+++ b/dragonfly/implementations/sensor_logger.py
@@ -44,9 +44,7 @@ class SensorLogger(Gogol, PostgreSQLInterface):
         ### Get the sensor name
         sensor_name = None
         if '.' in basic_deliver.routing_key:
-            logger.debug('basic_deliver.routing_key is: {}'.format(basic_deliver.routing_key))
             re_out = re.match(r'sensor_value.(?P<from>\S+)', basic_deliver.routing_key)
-            logger.debug('re_out.groupdict() is: {}'.format(re_out.groupdict()))
             sensor_name = re_out.groupdict()['from']
         # note that the following is deprecated in dripline 2.x, retained for compatibility
         else:
@@ -59,7 +57,7 @@ class SensorLogger(Gogol, PostgreSQLInterface):
                                          where_eq_dict={'endpoint_name':sensor_name},
                                         )
         if not this_type[1]:
-            logger.critical('endpoint with name "{}" was not found in database hence failed to log its value; might need it to add to the db'.format(sensor_name))
+            logger.critical('endpoint with name "{}" was not found in database hence failed to log its value; might need to add it to the db'.format(sensor_name))
         else:
             this_table = self.endpoints[self._sensor_type_map_table]
             this_type = this_table.do_select(return_cols=['type'],

--- a/dragonfly/implementations/sensor_logger.py
+++ b/dragonfly/implementations/sensor_logger.py
@@ -42,7 +42,10 @@ class SensorLogger(Gogol, PostgreSQLInterface):
         ### Get the sensor name
         sensor_name = None
         if '.' in basic_deliver.routing_key:
+            logger.debug('basic_deliver.routing_key is: {}'.format(basic_deliver.routing_key))
             re_out = re.match(r'sensor_value.(?P<from>\S+)', basic_deliver.routing_key)
+            logger.debug('re_out is: {}'.format(re_out))
+            logger.debug('re_out.groupdict() is: {}'.format(re_out.groupdict()))
             sensor_name = re_out.groupdict()['from']
         # note that the following is deprecated in dripline 2.x, retained for compatibility
         else:
@@ -55,7 +58,6 @@ class SensorLogger(Gogol, PostgreSQLInterface):
                                          where_eq_dict={'endpoint_name':sensor_name},
                                         )
         if not this_type[1]:
-            #logger.info('value not logged for <{}>'.format(sensor_name))
             logger.critical('endpoint with name "{}" was not found in database hence failed to log its value; might need it to add to the db'.format(sensor_name))
         else:
             self._sensor_types[sensor_name] = this_type[1][0][0]

--- a/dragonfly/implementations/sensor_logger.py
+++ b/dragonfly/implementations/sensor_logger.py
@@ -34,6 +34,7 @@ class SensorLogger(Gogol, PostgreSQLInterface):
         self._sensor_type_map_table = sensor_type_map_table
         self._sensor_types = {}
         self._data_tables = data_tables_dict
+        self.service = self
 
     def add_endpoint(self, endpoint):
         # forcing PostgreSQLInterface add_endpoint usage

--- a/dragonfly/implementations/sql_snapshot.py
+++ b/dragonfly/implementations/sql_snapshot.py
@@ -143,7 +143,7 @@ class SQLSnapshot(SQLTable):
                 logger.error('{}; in executing SQLAlchemy select statement to obtain endpoint_id for endpoint "{}"'.format(dripline_error.message,name))
                 return
             if not query_return:
-                logger.critical('endpoint with name "{}" not found in database hence failed to take snapshot of its value; might need it to add to the db'.format(name))
+                logger.critical('endpoint with name "{}" not found in database hence failed to take snapshot of its value; might need to add it to the db'.format(name))
                 continue
             else:
                 ept_id = query_return[0]['endpoint_id']


### PR DESCRIPTION
This update resolves issues #27 and #30 including the related issue of the sensor logger service crashing when receiving a broadcast.ping command. First, a misnamed enpoint whose value we attempt to log now broadcasts a useful logger.critical message and the service continues onto the next without crashing. Second, a run with a missing run name or a run name that is too long for the db raises an error that is now caught and the error message propagated to logger.critical and the user. In the general case that the run name is not populated then, in DAQProvider, the rest of the run procedures - that is ALL run procedures - are prevented from initializing; the service continues without crashing. Lastly, broadcast.ping is parsed correctly by the logger service and doesn't crash it. All tested in insectarium (branch of same name), and working well. 