### PR TITLE
Feature/ethernet redesign

### DIFF
--- a/dragonfly/implementations/ethernet_provider.py
+++ b/dragonfly/implementations/ethernet_provider.py
@@ -48,7 +48,7 @@ class EthernetProvider(Provider):
         command_terminator (str): string to append to commands
         response_terminator (str||None): string to strip from responses, this MUST exist for get method to function properly!
         bare_response_terminator (str||None): abbreviated string to strip from responses containing only prompt
-                                            : only used to handle non-standard glenlivet/lockin behavior
+                                            : only used to handle non-standard lockin behavior
         reply_echo_cmd (bool): set to True if command+command_terminator or just command are present in reply
         '''
         Provider.__init__(self, **kwargs)
@@ -169,7 +169,7 @@ class EthernetProvider(Provider):
                 if data.endswith(self.response_terminator):
                     terminator = self.response_terminator
                     break
-                # Special exception for bad communication with glenlivet
+                # Special exception for lockin data dump
                 elif self.bare_response_terminator and data.endswith(self.bare_response_terminator):
                     terminator = self.bare_response_terminator
                     break
@@ -179,12 +179,10 @@ class EthernetProvider(Provider):
                     raise exceptions.DriplineHardwareResponselessError("empty socket.recv packet from {}".format(self.socket_info[0]))
         except socket.timeout:
             logger.warning("socket.timeout condition met; received:\n{}".format(repr(data)))
-            if blank_command == False and data == '':
+            if blank_command == False:
                 logger.critical("Cannot connect to: {}".format(self.socket_info[0]))
                 raise exceptions.DriplineHardwareResponselessError("socket.timeout from {}".format(self.socket_info[0]))
-            else:
-                logger.critical("socket.timeout condition met with data from {}".format(self.socket_info[0]))
-                terminator = ''
+            terminator = ''
         logger.debug(repr(data))
         data = data[0:data.rfind(terminator)]
         return data

--- a/dragonfly/implementations/repeater_provider.py
+++ b/dragonfly/implementations/repeater_provider.py
@@ -28,15 +28,16 @@ class RepeaterProvider(Provider):
     def send_request(self, target, request):
         result = self.service.send_request(self._repeat_target, request, timeout=self._timeout)
         if result.retcode != 0:
-            msg = ''
-            if 'ret_msg' in result.payload:
-                msg = result.payload['ret_msg']
+            if 'return_msg' in result:
+                msg = result['return_msg']
+            else:
+                msg = ''
             # Exception 201 means wolfburn is having connection issues and isn't spamming errors.
             if result.retcode == 201:
                 raise exception_map[result.retcode](msg)
             else:
-                logger.critical("{} returned from {} with message {}. {} service crashing.".\
-                    format(exception_map[result.retcode],self._repeat_target,repr(msg),self.name))
+                logger.critical("{} returned from {} with message '{}'. {} service crashing.".\
+                    format(exception_map[result.retcode],self._repeat_target,msg,self.name))
                 sys.exit()
         return result.payload
 


### PR DESCRIPTION
Wrapup of issue #54 to address error paging to Slack.  Now if an instrument fails you can expect two slack pages:
- one saying you got a timeout
- second one elaborating either:
  - reconnect failed (socket issue, probably an unresponsive instrument)
  - reconnect succeeded but resend failed (probably a bad Spime)
  - reconnect succeeded and resend worked (ghost in the machine, don't worry)

If the connection can mysteriously heal itself after some time, a future page will tell you the connection is re-established.  Since Slack handler addresses messages as from the specific service, no socket information is provided in these pages.

In the special case of the lockin (or other repeater), there will be three messages:
- repeater got a timeout
- repeater reconnected, but still got a timeout
- since the repeater is fine, we blame the lockin, and the service is crashing

In summary, the Slack paging should now be more verbose and helpful.  More information has been placed in various warning loggers to help debug.  This should add functionality, not remove it.

The implementation is a little clunky, since `send` method handles all paging and I've added a nested `try...except` loop which catches and re-raises the same exceptions after paging.  Advice welcome.