### PR TITLE
Feature/generic daq set condition

### DIFF
--- a/dragonfly/implementations/daq_run_interface.py
+++ b/dragonfly/implementations/daq_run_interface.py
@@ -268,6 +268,8 @@ class RSAAcquisitionInterface(DAQProvider):
         if Nerrors != '0':
             raise core.exceptions.DriplineGenericDAQError('RSA system has {} error(s) in the queue: check them with <dragonfly get rsa_system_error_queue -b myrna.p8>'.format(Nerrors))
 
+        return "checks successful"
+
     def determine_RF_ROI(self):
         logger.info('trying to determine roi')
 

--- a/dragonfly/implementations/daq_run_interface.py
+++ b/dragonfly/implementations/daq_run_interface.py
@@ -167,18 +167,18 @@ class DAQProvider(core.Provider):
         self._run_time = int(run_time)
         if self._daq_in_safe_mode:
             logger.info("DAQ in safe mode")
-            raise Exception
+            raise core.exceptions.DriplineDAQNotEnabled("DAQ is not enabled: enable it using <dragonfly cmd broadcast.set_condition 0 -b myrna.p8>")
 
         # self.start_run(run_name)
         logger.debug('testing if the DAQ is running')
         result = self.is_running
         if result == True:
-            raise core.exceptions.DriplineHardwareError('DAQ is already running: aborting run')
+            raise core.exceptions.DriplineDAQRunning('DAQ is already running: aborting run')
 
         # do the last minutes checks: DAQ specific
         self._do_checks()
 
-        # get run_id
+        # get run_id and do pre_run gets
         self.start_run(run_name)
 
         # call start_run method in daq_target
@@ -258,12 +258,12 @@ class RSAAcquisitionInterface(DAQProvider):
     def _do_checks(self):
         the_ref = self.provider.set('rsa_osc_source', 'EXT')['value_raw']
         if the_ref != 'EXT':
-            raise core.exceptions.DriplineHardwareError('RSA external ref found to be <{}> (!="EXT")'.format(the_ref))
+            raise core.exceptions.DriplineGenericDAQError('RSA external ref found to be <{}> (!="EXT")'.format(the_ref))
 
         # counting the number of errors in the RSA system queue and aborting the data taking if Nerrors>0
         Nerrors = self.provider.get('rsa_system_error_count')['value_raw']
         if Nerrors != '0':
-            raise core.exceptions.DriplineHardwareError('RSA system has {} error(s) in the queue: check them with <dragonfly get rsa_system_error_queue -b myrna.p8>'.format(Nerrors))
+            raise core.exceptions.DriplineGenericDAQError('RSA system has {} error(s) in the queue: check them with <dragonfly get rsa_system_error_queue -b myrna.p8>'.format(Nerrors))
 
     def end_run(self):
         # call end_run method in daq_target

--- a/dragonfly/implementations/daq_run_interface.py
+++ b/dragonfly/implementations/daq_run_interface.py
@@ -187,10 +187,8 @@ class DAQProvider(core.Provider):
         # call start_run method in daq_target
         directory = "\\".join([self.data_directory_path, '{:09d}'.format(self.run_id)])
         filename = "{}{:09d}".format(self.filename_prefix, self.run_id)
-        self.provider.cmd(self._daq_target, 'start_run', [directory, filename])
+        self._take_data_now(directory,filename)
 
-        logger.info("Adding {} sec timeout for run <{}> duration".format(self._run_time, self.run_id))
-        self._stop_handle = self.service._connection.add_timeout(self._run_time, self.end_run)
         return self.run_id
 
     def _set_condition(self,number):
@@ -271,6 +269,11 @@ class RSAAcquisitionInterface(DAQProvider):
             raise core.exceptions.DriplineGenericDAQError('RSA system has {} error(s) in the queue: check them with <dragonfly get rsa_system_error_queue -b myrna.p8>'.format(Nerrors))
 
         return "checks successful"
+
+    def _take_data_now(self,directory,filename):
+        self.provider.cmd(self._daq_target, 'start_run', [directory, filename])
+        logger.info("Adding {} sec timeout for run <{}> duration".format(self._run_time, self.run_id))
+        self._stop_handle = self.service._connection.add_timeout(self._run_time, self.end_run)
 
     # def _set_condition(self,number):
     #     logger.info("Use the generic DAQProvider _set_condition method")

--- a/dragonfly/implementations/daq_run_interface.py
+++ b/dragonfly/implementations/daq_run_interface.py
@@ -170,7 +170,7 @@ class DAQProvider(core.Provider):
         self._run_time = int(run_time)
         if self._daq_in_safe_mode:
             logger.info("DAQ in safe mode")
-            raise core.exceptions.DriplineDAQNotEnabled("DAQ is not enabled: enable it using <dragonfly cmd broadcast.set_condition 0 -b myrna.p8>")
+            raise core.exceptions.DriplineDAQNotEnabled("{} is not enabled: enable it using <dragonfly cmd broadcast.set_condition 0 -b myrna.p8>".format(self.daq_name))
 
         # self.start_run(run_name)
         logger.debug('testing if the DAQ is running')
@@ -198,7 +198,9 @@ class DAQProvider(core.Provider):
         if number in self._set_condition_list:
             logger.debug('putting myself in safe_mode')
             self._daq_in_safe_mode = True
-            self.end_run()
+            if self.is_running:
+                self.end_run()
+                logger.critical("Run {} ended".format(self.run_id))
             logger.critical('Condition {} reached!'.format(number))
         elif number == 0:
             logger.debug('getting out of safe_mode')
@@ -269,6 +271,10 @@ class RSAAcquisitionInterface(DAQProvider):
             raise core.exceptions.DriplineGenericDAQError('RSA system has {} error(s) in the queue: check them with <dragonfly get rsa_system_error_queue -b myrna.p8>'.format(Nerrors))
 
         return "checks successful"
+
+    # def _set_condition(self,number):
+    #     logger.info("Use the generic DAQProvider _set_condition method")
+    #     super(RSAAcquisitionInterface,self)._set_condition(number)
 
     def determine_RF_ROI(self):
         logger.info('trying to determine roi')

--- a/dragonfly/implementations/daq_run_interface.py
+++ b/dragonfly/implementations/daq_run_interface.py
@@ -100,6 +100,9 @@ class DAQProvider(core.Provider):
             raise core.exceptions.DriplineValueError('failed to insert run_name to the db, obtain run_id, and start_timestamp. run "<{}>" not started\nerror:\n{}'.format(value,str(err)))
 
     def end_run(self):
+        # call end_run method in daq_target
+        self.provider.cmd(self._daq_target, 'end_run')
+
         if self.run_id is None:
             raise core.DriplineValueError("No run to end: run_id is None.")
         self._do_snapshot()
@@ -264,12 +267,6 @@ class RSAAcquisitionInterface(DAQProvider):
         Nerrors = self.provider.get('rsa_system_error_count')['value_raw']
         if Nerrors != '0':
             raise core.exceptions.DriplineGenericDAQError('RSA system has {} error(s) in the queue: check them with <dragonfly get rsa_system_error_queue -b myrna.p8>'.format(Nerrors))
-
-    def end_run(self):
-        # call end_run method in daq_target
-        self.provider.cmd(self._daq_target, 'end_run')
-        # call global DAQ end_run method
-        super(RSAAcquisitionInterface, self).end_run()
 
     def determine_RF_ROI(self):
         logger.info('trying to determine roi')

--- a/dragonfly/status_log_handlers/amqp_handler.py
+++ b/dragonfly/status_log_handlers/amqp_handler.py
@@ -33,10 +33,6 @@ class AMQPHandler(logging.Handler):
             self.username = 'dripline'
         else:
             self.username = name
-        # Test message to be sent everytime a dragonfly command is called
-        # severity = 'status_message.{}.{}'.format(this_channel,self.username)
-        # print('sending to alerts exchange with severity {} message ({})'.format(severity,'hello world'))
-        # self.connection_to_alert.send_status_message(severity=severity,alert='hello world')
 
     def update_parser(self, parser):
         parser.add_argument('--'+self.argparse_flag_str,
@@ -57,10 +53,5 @@ class AMQPHandler(logging.Handler):
     def emit(self, record):
         this_channel = 'p8_alerts'
         severity = 'status_message.{}.{}'.format(this_channel,self.username)
-        print('sending to alerts exchange with severity {} message ({})'.format(severity,record.msg))
 
         self.connection_to_alert.send_status_message(severity=severity,alert=record.msg)
-        # print('supposed to do an emit')
-        # #this_channel = '#bot_integration_test'
-        # if self.slackclient is not None:
-        #     self.slackclient.api_call('chat.postMessage', channel=this_channel, text=record.msg, username='dripline', as_user='true')


### PR DESCRIPTION
As discussed on Slack, I have moved a lot of the items in the start_run of the RSADAQInterface into the base class DAQProvider.
This makes the code much cleaner, but also shows what the required DAQ-specific methods for every new DAQ system are (currently is_running, _do_checks and determine_RF_ROI).
This new structure allows more flexibility invading new features across all DAQ system and helps to keep them coherent.
The set_condition is now a DAQ_Provider class thing, the language used to comment in the logger is supposed to be generic. 
The set_condition also allows us to stop the current run (if is_running returns True): this could be useful if we want to decrease the limit of the disk_monitor_interface.

@laroque @nsoblath Could you have a look and check that this is flexible enough for the ROACH?