### PR TITLE
saving roach setup and psyllid mask for triggered runs

### DIFF
--- a/dragonfly/implementations/psyllid_provider.py
+++ b/dragonfly/implementations/psyllid_provider.py
@@ -96,7 +96,7 @@ class PsyllidProvider(core.Provider):
         target = '{}.active-config.{}.{}'.format(self.queue_dict[channel],
                                                  str(self.channel_dict[channel]),
                                                  key)
-        self.provider.get(target)
+        return self.provider.get(target)
 
 
     def get_acquisition_mode(self, channel):

--- a/dragonfly/implementations/psyllid_provider.py
+++ b/dragonfly/implementations/psyllid_provider.py
@@ -92,6 +92,13 @@ class PsyllidProvider(core.Provider):
         raise core.exceptions.DriplineGenericDAQError('active_channels cannot be set')
 
 
+    def get_active_config(self, channel, key):
+        target = '{}.active-config.{}.{}'.format(self.queue_dict[channel],
+                                                 str(self.channel_dict[channel]),
+                                                 key)
+        self.provider.get(target)
+
+
     def get_acquisition_mode(self, channel):
         '''
         Tests whether psyllid is in streaming or triggering mode
@@ -460,10 +467,7 @@ class PsyllidProvider(core.Provider):
         self.start_run(channel ,1000, self.temp_file)
         time.sleep(1)
 
-        logger.info('Write mask to file')
-        request = 'run-daq-cmd.{}.fmt.write-mask'.format(str(self.channel_dict[channel]))
-        payload = {'filename': filename}
-        self.provider.cmd(self.queue_dict[channel], request, payload=payload)
+        self._write_trigger_mask(channel, filename)
 
         logger.info('Telling psyllid to use monarch again for next run')
         self.provider.set(self.queue_dict[channel]+'.use-monarch', True)
@@ -475,3 +479,13 @@ class PsyllidProvider(core.Provider):
         logger.info('Switch frequency mask trigger to apply-trigger')
         request = 'run-daq-cmd.{}.fmt.apply-trigger'.format(str(self.channel_dict[channel]))
         self.provider.cmd(self.queue_dict[channel],request)
+
+
+    def _write_trigger_mask(self, channel, filename):
+        '''
+        Tells psyllid to write a frequency mask to a json file
+        '''
+        logger.info('Write mask to file')
+        request = 'run-daq-cmd.{}.fmt.write-mask'.format(str(self.channel_dict[channel]))
+        payload = {'filename': filename}
+        self.provider.cmd(self.queue_dict[channel], request, payload=payload)

--- a/dragonfly/implementations/roach_daq_run_interface.py
+++ b/dragonfly/implementations/roach_daq_run_interface.py
@@ -212,18 +212,20 @@ class ROACH1ChAcquisitionInterface(DAQProvider):
         '''
 
         setup = { 'roach' : self.provider.get('{}.registers'.format(self.daq_target)) }
-        psyllid_config_kwargs = { 'target' : self.psyllid_interface,
+        psyllid_config_kwargs = {
+                                  'target' : self.psyllid_interface,
                                   'method_name' : 'get_active_config',
-                                  'channel' : self.channel_id,
-                                  'key' : 'prf' }
+                                  'payload' : { 'channel' : self.channel_id,
+                                                'key' : 'prf' }
+                                }
         setup.update( { 'psyllid' :
-                            'prf' : self.provider.cmd(**psyllid_config_kwargs) } )
+                            { 'prf' : self.provider.cmd(**psyllid_config_kwargs) } } )
 
         if self.acquisition_mode == 'triggering':
             payload = {'channel':self.channel_id, 'filename':'{}/{}_mask.json'.format(directory,filename)}
             self.provider.cmd(self.psyllid_interface, '_write_trigger_mask', payload=payload)
             for key in ('fmt', 'tfrr', 'eb'):
-                psyllid_config_kwargs.update( { 'key' : key } )
+                psyllid_config_kwargs['payload'].update( { 'key' : key } )
                 setup['psyllid'].update( { key : self.provider.cmd(**psyllid_config_kwargs) } )
         payload = { 'contents': setup,
                     'filename': '{}/{}_setup.json'.format(directory,filename) }

--- a/dragonfly/subcommands/run_scripting.py
+++ b/dragonfly/subcommands/run_scripting.py
@@ -391,7 +391,8 @@ class RunScript(object):
     def action_cmd(self, cmds, **kwargs):
         # mandatory fields are <endpoint> and <method_name> for each cmd
         logger.info('doing cmd block')
-        for cmd_kwargs in cmds:
+        for this_cmd in cmds:
+            cmd_kwargs = this_cmd.copy()
             if 'timeout' in cmd_kwargs:
                 logger.debug('timeout set to {}'.format(cmd_kwargs['timeout']))
             reformat = cmd_kwargs.pop('asteval_format',{})


### PR DESCRIPTION
This should add in the missing setup information to our runs:
- psyllid active node config
- psyllid frequency mask
- roach registers