### PR TITLE
Feature/default threshold type

### DIFF
--- a/dragonfly/implementations/psyllid_provider.py
+++ b/dragonfly/implementations/psyllid_provider.py
@@ -348,9 +348,6 @@ class PsyllidProvider(core.Provider):
         '''
         Does all time window settings at once
         '''
-        if self.mode_dict[channel] != 'triggering':
-            logger.error('Psyllid instance is not in triggering mode')
-            raise core.exceptions.DriplineGenericDAQError('Psyllid instance is not in triggering mode')
         # apply settings
         self.set_pretrigger_time( pretrigger_time, channel )
         self.set_skip_tolerance( skip_tolerance, channel )
@@ -362,10 +359,6 @@ class PsyllidProvider(core.Provider):
         '''
         Gets and returns all time window settings
         '''
-        if self.mode_dict[channel] != 'triggering':
-            logger.error('Psyllid instance is not in triggering mode')
-            raise core.exceptions.DriplineGenericDAQError('Psyllid instance is not in triggering mode')
-
         pretrigger_time = self.get_pretrigger_time( channel )
         skip_tolerance = self.get_skip_tolerance( channel )
 

--- a/dragonfly/implementations/psyllid_provider.py
+++ b/dragonfly/implementations/psyllid_provider.py
@@ -115,30 +115,6 @@ class PsyllidProvider(core.Provider):
         return {'mode': self.mode_dict[channel]}
 
 
-
-    def get_number_of_streams(self, channel):
-        '''
-        Counts how many streams (streaming or triggering) are set up in psyllid and retuns number
-        '''
-        stream_count = 0
-        for i in range(3):
-            try:
-                request = '.node-config.ch'+str(i)+'.strw'
-                self.provider.get(self.queue_dict[channel]+request)
-                stream_count += 1
-                self.mode_dict[channel]='streaming'
-            except core.exceptions.DriplineError:
-                try:
-                    request = '.node-config.ch'+str(i)+'.trw'
-                    self.provider.get(self.queue_dict[channel]+request)
-                    stream_count += 1
-                    self.mode_dict[channel]='triggering'
-                except core.exceptions.DriplineError:
-                    pass
-        logger.info('Number of streams for channel {}: {}'.format(channel, stream_count))
-        return stream_count
-
-
     def request_status(self, channel):
         '''
         Asks the psyllid instance what state it is in and returns that state

--- a/dragonfly/implementations/psyllid_provider.py
+++ b/dragonfly/implementations/psyllid_provider.py
@@ -103,16 +103,15 @@ class PsyllidProvider(core.Provider):
         '''
         Tests whether psyllid is in streaming or triggering mode
         '''
-        try:
+        request = '{}.node-list.{}'.format(self.queue_dict[channel], self.channel_dict[channel])
+        node_list = self.provider.get(request)['nodes']
+
+        if 'trw' in node_list:
             self.mode_dict[channel] = 'triggering'
-            self.get_central_frequency(channel)
-        except core.exceptions.DriplineError:
+        elif 'strw' in node_list:
             self.mode_dict[channel] = 'streaming'
-            try:
-                self.get_central_frequency(channel)
-            except core.exceptions.DriplineError as e:
-                self.mode_dict[channel] = None
-                raise e
+        else:
+            self.mode_dict[channel] = None
         return {'mode': self.mode_dict[channel]}
 
 

--- a/dragonfly/implementations/roach_daq_run_interface.py
+++ b/dragonfly/implementations/roach_daq_run_interface.py
@@ -488,6 +488,8 @@ class ROACH1ChAcquisitionInterface(DAQProvider):
         '''
         Returns pretrigger time and skip tolerance
         '''
+        if self.acquisition_mode is not 'triggering':
+            return False
         result = self.provider.cmd(self.psyllid_interface, 'get_time_window', payload = self.payload_channel)
         return result
 

--- a/dragonfly/implementations/roach_daq_run_interface.py
+++ b/dragonfly/implementations/roach_daq_run_interface.py
@@ -527,6 +527,7 @@ class ROACH1ChAcquisitionInterface(DAQProvider):
         if self.default_trigger_dict == None:
             raise core.exceptions.DriplineGenericDAQError('No default trigger settings present')
         else:
+            self.threshold = self.default_trigger['threshold-type']
             self.configure_trigger(threshold=self.default_trigger_dict['threshold'], high_threshold=self.default_trigger_dict['high_threshold'], n_triggers=self.default_trigger_dict['n_triggers'])
             self.configure_time_window(pretrigger_time=float(self.default_trigger_dict['pretrigger_time']), skip_tolerance=float(self.default_trigger_dict['skip_tolerance']))
 

--- a/dragonfly/implementations/roach_daq_run_interface.py
+++ b/dragonfly/implementations/roach_daq_run_interface.py
@@ -463,7 +463,7 @@ class ROACH1ChAcquisitionInterface(DAQProvider):
         '''
         Returns all trigger settings
         '''
-        if self.acquisition_mode == None:
+        if self.acquisition_mode is not 'triggering':
             return False
         result = self.provider.cmd(self.psyllid_interface, 'get_trigger_configuration', payload = self.payload_channel)
         return result
@@ -527,7 +527,7 @@ class ROACH1ChAcquisitionInterface(DAQProvider):
         if self.default_trigger_dict == None:
             raise core.exceptions.DriplineGenericDAQError('No default trigger settings present')
         else:
-            self.threshold_type = self.default_trigger['threshold-type']
+            self.threshold_type = self.default_trigger_dict['threshold-type']
             self.configure_trigger(threshold=self.default_trigger_dict['threshold'], high_threshold=self.default_trigger_dict['high_threshold'], n_triggers=self.default_trigger_dict['n_triggers'])
             self.configure_time_window(pretrigger_time=float(self.default_trigger_dict['pretrigger_time']), skip_tolerance=float(self.default_trigger_dict['skip_tolerance']))
 

--- a/dragonfly/implementations/roach_daq_run_interface.py
+++ b/dragonfly/implementations/roach_daq_run_interface.py
@@ -463,8 +463,6 @@ class ROACH1ChAcquisitionInterface(DAQProvider):
         '''
         Returns all trigger settings
         '''
-        if self.acquisition_mode is not 'triggering':
-            return False
         result = self.provider.cmd(self.psyllid_interface, 'get_trigger_configuration', payload = self.payload_channel)
         return result
 
@@ -488,8 +486,6 @@ class ROACH1ChAcquisitionInterface(DAQProvider):
         '''
         Returns pretrigger time and skip tolerance
         '''
-        if self.acquisition_mode is not 'triggering':
-            return False
         result = self.provider.cmd(self.psyllid_interface, 'get_time_window', payload = self.payload_channel)
         return result
 

--- a/dragonfly/implementations/roach_daq_run_interface.py
+++ b/dragonfly/implementations/roach_daq_run_interface.py
@@ -172,7 +172,7 @@ class ROACH1ChAcquisitionInterface(DAQProvider):
             threshold = self.threshold
             logger.info('threshold from psyllid is: {}'.format(threshold))
             if self.stored_threshold != threshold:
-                logger.error('Threshold mismatch: psyllid power-snr-threshold is {}, but should be {}'.format(threshold, self.stored_threshold))
+                logger.error('Threshold mismatch: psyllid threshold is {}, but should be {}'.format(threshold, self.stored_threshold))
                 raise core.exceptions.DriplineGenericDAQError('Threshold mismatch')
 
         return "checks successful"
@@ -463,7 +463,7 @@ class ROACH1ChAcquisitionInterface(DAQProvider):
         '''
         Returns all trigger settings
         '''
-        if self.trigger_type == None:
+        if self.acquisition_mode == None:
             return False
         result = self.provider.cmd(self.psyllid_interface, 'get_trigger_configuration', payload = self.payload_channel)
         return result
@@ -527,7 +527,7 @@ class ROACH1ChAcquisitionInterface(DAQProvider):
         if self.default_trigger_dict == None:
             raise core.exceptions.DriplineGenericDAQError('No default trigger settings present')
         else:
-            self.threshold = self.default_trigger['threshold-type']
+            self.threshold_type = self.default_trigger['threshold-type']
             self.configure_trigger(threshold=self.default_trigger_dict['threshold'], high_threshold=self.default_trigger_dict['high_threshold'], n_triggers=self.default_trigger_dict['n_triggers'])
             self.configure_time_window(pretrigger_time=float(self.default_trigger_dict['pretrigger_time']), skip_tolerance=float(self.default_trigger_dict['skip_tolerance']))
 


### PR DESCRIPTION
- removed exception raising in psyllid_provider if acquisition_mode is None.
- replaced a trigger_type check with acquisition_mode check in roach_daq_run_interface (which by itself would resolve the error spamming issue because that check is not made on a state but actually asks psyllid_provider which then knows the mode)
- added threshold type to default trigger settings.

Do we also want to update the acquisition_mode check, so that dragonfly gets psyllid's node config?

I haven't tested this branch yet.
