### PR TITLE
fix warning level problem

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -12,6 +12,7 @@ Luis Saldana [5]
 Matthew Sternberg [3]
 Luiz de Vivieros [4]
 Megan Wachtendonk [3]
+yadiw [3]
 
 
 Institutions

--- a/AUTHORS
+++ b/AUTHORS
@@ -12,7 +12,7 @@ Luis Saldana [5]
 Matthew Sternberg [3]
 Luiz de Vivieros [4]
 Megan Wachtendonk [3]
-yadiw [3]
+Yadi Wang [3]
 
 
 Institutions

--- a/dragonfly/implementations/dungbeetle.py
+++ b/dragonfly/implementations/dungbeetle.py
@@ -28,33 +28,26 @@ class DungBeetle(Endpoint,Scheduler):
         self.root_dirs = root_dirs
         self.max_age = datetime.timedelta(**max_age)
         self.ignore_dirs = ignore_dirs
-        self.processed_dirs = {}
 
     # recursively delete empty directories
-    def del_dir(self, path, min_creation_time, processed_dirs_per_cycle):
+    def del_dir(self, path, min_creation_time, dirs_to_be_warned):
         if os.path.isdir(path):
             creation_time = datetime.datetime.fromtimestamp(os.path.getctime(path))
             no_sub_dir = True
             for item in os.listdir(path):
                 sub_path = os.path.join(path, item)
                 no_sub_dir = no_sub_dir and (not os.path.isdir(sub_path))
-                self.del_dir(sub_path, min_creation_time, processed_dirs_per_cycle)
+                self.del_dir(sub_path, min_creation_time, dirs_to_be_warned)
             if creation_time < min_creation_time and (not path in self.ignore_dirs):
                 try:
                     os.rmdir(path)
                     logger.info(" path [{}] has been removed.".format(path))
                 except OSError, err:
                     if no_sub_dir:
-                        processed_dirs_per_cycle.append(path)
-                        if path not in self.processed_dirs:
-                            self.processed_dirs[path] = 1
-                        else:
-                            self.processed_dirs[path] += 1
-                        if self.processed_dirs[path] <= 5 or self.processed_dirs[path] % 5 == 0:
-                            logger.warning(" path [{}] not removed because not empty".format(path))
+                        dirs_to_be_warned.append(path)
 
     # clean up empty directories under a specific directory without deleting itself
-    def clean_dir(self, processed_dirs_per_cycle):
+    def clean_dir(self, dirs_to_be_warned):
         logger.debug("going to clean directories")
         min_creation_time = datetime.datetime.now() - self.max_age
         for root_dir in self.root_dirs:
@@ -62,15 +55,13 @@ class DungBeetle(Endpoint,Scheduler):
             if os.path.isdir(root_dir):
                 for item in os.listdir(root_dir):
                     sub_path = os.path.join(root_dir, item)
-                    self.del_dir(sub_path, min_creation_time, processed_dirs_per_cycle)
+                    self.del_dir(sub_path, min_creation_time, dirs_to_be_warned)
             else:
                 raise Exception(" path [{}] does not exist.".format(root_dir))
 
     def scheduled_action(self):
         logger.info("doing scheduled check")
-        processed_dirs_per_cycle = []
-        self.clean_dir(processed_dirs_per_cycle)
-        for directory in list(self.processed_dirs):
-            if directory not in processed_dirs_per_cycle:
-                del self.processed_dirs[directory]
-
+        dirs_to_be_warned = []
+        self.clean_dir(dirs_to_be_warned)
+        message = str(len(dirs_to_be_warned)) + 'path(s) not removed because not empty: ' + str(dirs_to_be_warned)
+        

--- a/dragonfly/implementations/dungbeetle.py
+++ b/dragonfly/implementations/dungbeetle.py
@@ -16,11 +16,13 @@ class DungBeetle(Endpoint,Scheduler):
                  root_dirs = [],
                  max_age = {"hours":2},
                  ignore_dirs = [],
+                 warning_interval = 12,
                  **kwargs):
         '''
         root_dirs (list of str): list of strings naming paths to monitor, these dirs are not removed
         max_age (dict): min age for a directory to be removed if empty, is a dict of kwargs to datetime.timedelta.__init__
         ignore_dirs (list of str): list of string names of paths to ignore, each must be a full path (starting with the corresponding value from root_dirs)
+        warning_interval (int): the number of cycles that a warning will be sent when a directory has not been removed for a long time
         '''
         Endpoint.__init__(self, **kwargs)
         Scheduler.__init__(self, **kwargs)
@@ -28,40 +30,62 @@ class DungBeetle(Endpoint,Scheduler):
         self.root_dirs = root_dirs
         self.max_age = datetime.timedelta(**max_age)
         self.ignore_dirs = ignore_dirs
+        self.processed_dirs = {}
+        self.warning_interval = warning_interval
 
     # recursively delete empty directories
-    def del_dir(self, path, min_creation_time, dirs_to_be_warned):
+    def del_dir(self, path, min_creation_time, processed_dirs_per_cycle, new_dirs):
         if os.path.isdir(path):
             creation_time = datetime.datetime.fromtimestamp(os.path.getctime(path))
             no_sub_dir = True
             for item in os.listdir(path):
                 sub_path = os.path.join(path, item)
                 no_sub_dir = no_sub_dir and (not os.path.isdir(sub_path))
-                self.del_dir(sub_path, min_creation_time, dirs_to_be_warned)
+                self.del_dir(sub_path, min_creation_time, processed_dirs_per_cycle, new_dirs)
             if creation_time < min_creation_time and (not path in self.ignore_dirs):
                 try:
                     os.rmdir(path)
                     logger.info(" path [{}] has been removed.".format(path))
                 except OSError, err:
                     if no_sub_dir:
-                        dirs_to_be_warned.append(path)
+                        processed_dirs_per_cycle.append(path)
+                        if path not in self.processed_dirs:
+                            self.processed_dirs[path] = 1
+                            new_dirs.append(path)
+                        else:
+                            self.processed_dirs[path] += 1
 
     # clean up empty directories under a specific directory without deleting itself
-    def clean_dir(self, dirs_to_be_warned):
-        logger.debug("going to clean directories")
+    def clean_dir(self, processed_dirs_per_cycle, new_dirs):
+        logger.debug(" going to clean directories")
         min_creation_time = datetime.datetime.now() - self.max_age
         for root_dir in self.root_dirs:
-            logger.debug("checking {}".format(root_dir))
+            logger.debug(" checking {}".format(root_dir))
             if os.path.isdir(root_dir):
                 for item in os.listdir(root_dir):
                     sub_path = os.path.join(root_dir, item)
-                    self.del_dir(sub_path, min_creation_time, dirs_to_be_warned)
+                    self.del_dir(sub_path, min_creation_time, processed_dirs_per_cycle, new_dirs)
             else:
                 raise Exception(" path [{}] does not exist.".format(root_dir))
 
     def scheduled_action(self):
-        logger.info("doing scheduled check")
-        dirs_to_be_warned = []
-        self.clean_dir(dirs_to_be_warned)
-        message = str(len(dirs_to_be_warned)) + 'path(s) not removed because not empty: ' + str(dirs_to_be_warned)
-        
+        logger.info(" doing scheduled check")
+        processed_dirs_per_cycle = []
+        new_warning_list = []
+        old_warning_list = []
+        self.clean_dir(processed_dirs_per_cycle, new_warning_list)
+        for directory in list(self.processed_dirs):
+            if directory not in processed_dirs_per_cycle:
+                del self.processed_dirs[directory]
+            elif self.processed_dirs[directory]  > 1 and self.processed_dirs[directory ]% self.warning_interval == 1:
+                old_warning_list.append(directory)
+        message = ''
+        new_list_length = len(new_warning_list)
+        old_list_length = len(old_warning_list)
+        if new_list_length > 0:
+            message += ' ' + str(new_list_length) + ' new path(s) not removed because not empty: {}'.format(new_warning_list) + '\n'
+        if old_list_length > 0:
+            message += ' ' + str(old_list_length) + ' old path(s) not removed for more than ' + str(self.warning_interval) + ' cycles: {}'.format(old_warning_list) + '\n'
+        if message != '':
+            logger.warning(message)
+            

--- a/dragonfly/implementations/dungbeetle.py
+++ b/dragonfly/implementations/dungbeetle.py
@@ -70,7 +70,7 @@ class DungBeetle(Endpoint,Scheduler):
         logger.info("doing scheduled check")
         processed_dirs_per_cycle = []
         self.clean_dir(processed_dirs_per_cycle)
-        for dir in self.processed_dirs:
-            if dir not in processed_dirs_per_cycle:
-                del self.processed_dirs[dir]
+        for directory in list(self.processed_dirs):
+            if directory not in processed_dirs_per_cycle:
+                del self.processed_dirs[directory]
 

--- a/dragonfly/implementations/dungbeetle.py
+++ b/dragonfly/implementations/dungbeetle.py
@@ -77,7 +77,7 @@ class DungBeetle(Endpoint,Scheduler):
         for directory in list(self.processed_dirs):
             if directory not in processed_dirs_per_cycle:
                 del self.processed_dirs[directory]
-            elif self.processed_dirs[directory]  > 1 and self.processed_dirs[directory ]% self.warning_interval == 1:
+            elif self.processed_dirs[directory] > 1 and self.processed_dirs[directory] % self.warning_interval == 1:
                 old_warning_list.append(directory)
         message = ''
         new_list_length = len(new_warning_list)

--- a/dragonfly/implementations/dungbeetle.py
+++ b/dragonfly/implementations/dungbeetle.py
@@ -33,15 +33,18 @@ class DungBeetle(Endpoint,Scheduler):
     def del_dir(self, path, min_creation_time):
         if os.path.isdir(path):
             creation_time = datetime.datetime.fromtimestamp(os.path.getctime(path))
+            no_sub_dir = True
             for item in os.listdir(path):
                 sub_path = os.path.join(path, item)
+                no_sub_dir = no_sub_dir and (not os.path.isdir(sub_path))
                 self.del_dir(sub_path, min_creation_time)
             if creation_time < min_creation_time and (not path in self.ignore_dirs):
                 try:
                     os.rmdir(path)
                     logger.info(" path [{}] has been removed.".format(path))
                 except OSError, err:
-                    logger.warning(" path [{}] not removed because not empty".format(path))
+                    if no_sub_dir:
+                        logger.warning(" path [{}] not removed because not empty".format(path))
 
     # clean up empty directories under a specific directory without deleting itself
     def clean_dir(self):

--- a/examples/dungbeetle.yaml
+++ b/examples/dungbeetle.yaml
@@ -11,6 +11,7 @@ endpoints:
     max_age:
       seconds: 5
       minutes: 1
+    warning_interval: 12
     schedule_interval: 20
 setup_calls:
   - target: dungbeetle

--- a/examples/dungbeetle.yaml
+++ b/examples/dungbeetle.yaml
@@ -18,4 +18,4 @@ setup_calls:
     method: _on_set
     args: "on"
     kwargs:
-        routing_key_specifier: logging_status
+        routing_key_specifier: schedule_status


### PR DESCRIPTION
 - now directories with sub-directories don't send a warning any more.
 - when a certain directory triggers the same warning multiple times, it will now send it normally in the first 5 cycles, and then one warning per 5 cycles.
