### PR TITLE
Feature/at_operator more small fixes

### DIFF
--- a/dragonfly/implementations/at_operator.py
+++ b/dragonfly/implementations/at_operator.py
@@ -87,7 +87,7 @@ class AtOperator(SlowSubprocessMixin, Endpoint):
             slack = config_file['slack']['operator']
             self.slack_client = slackclient.SlackClient(slack)
         else:
-            logger.critical('Unable to find slack credentials for operator bot in <~/.project8_authentications.json>')
+            logger.critical('Unable to find slack credentials for operator bot in {}'.format(self.authentication_path))
             os._exit(1)
 
     def get_calendar_credentials(self):


### PR DESCRIPTION
copy and paste from the PR I closed yesterday:

> Basically the same as the Go Operator.
call the operator listed on Google calendar when someone do "@/operator" in any project 8 slack channel (an all day shift is interpreted as 9am-9am).
(exactly!) same helper commands available.
regularly send messages when the bot gets started / the operator changes / it's being terminated, if a valid "monitor channel" is specified.
regularly update information such as Google calendar events / slack users.

I have finals next week so might respond slowlier though :(
