### PR TITLE
add sleep option to multido to allow time before check

### DIFF
--- a/dragonfly/implementations/multido.py
+++ b/dragonfly/implementations/multido.py
@@ -172,7 +172,7 @@ class MultiDo(Endpoint):
 
             # if the value we are checking is a float/int
             if isinstance(value_get, (int,float)):
-                if not isinstance(target_value, (int,float)):
+                if not isinstance(target_value, (int, float)):
                     try:
                         target_value = float(target_value)
                     except ValueError:
@@ -183,37 +183,37 @@ class MultiDo(Endpoint):
                         tolerance = details['tolerance']
                     else:
                         tolerance = None
-                    if tolerance is None:
+                    if tolerance==None:
                         logger.debug('No tolerance given: assigning an arbitrary tolerance (1.)')
                         tolerance = 1.
-                    if not isinstance(tolerance,float) and not isinstance(tolerance,int) and not isinstance(tolerance,str):
+                    if not isinstance(tolerance, float) and not isinstance(tolerance, int) and not isinstance(tolerance, str):
                         logger.warning('tolerance is not a float or a string: assigning an arbitrary tolerance (1.)')
                         tolerance = 1.
-                    if isinstance(tolerance,float) or isinstance(tolerance,int):
+                    if isinstance(tolerance, float) or isinstance(tolerance, int):
                         if tolerance == 0:
                             logger.debug('tolerance zero inacceptable: setting tolerance to 1.')
                             tolerance = 1.
                         logger.debug('testing a-t<b<a+t')
                         if target_value -  tolerance <= value_get and value_get <= target_value + tolerance:
-                            logger.info('the value get <{}> ({}) is included in the target_value ({}) +- tolerance ({})'.format(a_target,value_get,target_value,tolerance))
+                            logger.info('the value get <{}> ({}) is included in the target_value ({}) +- tolerance ({})'.format(a_target, value_get, target_value, tolerance))
                         else:
-                            raise exceptions.DriplineValueError('{} value get ({}) is NOT included in the target_value ({}) +- tolerance ({}): stopping here!'.format(a_target,value_get,target_value,tolerance))
-                    elif isinstance(tolerance,str):
+                            raise exceptions.DriplineValueError('{} value get ({}) is NOT included in the target_value ({}) +- tolerance ({}): stopping here!'.format(a_target, value_get, target_value, tolerance))
+                    elif isinstance(tolerance, str):
                         if '%' not in tolerance:
                             logger.debug('absolute tolerance')
                             tolerance = float(tolerance)
                         else:
                             logger.debug('relative tolerance')
                             match_number = re.compile('-?\ *[0-9]+\.?[0-9]*(?:[Ee]\ *-?\ *[0-9]+)?')
-                            tolerance = [float(x) for x in re.findall(match_number, tolerance)][0]*target_value/100.
+                            tolerance = [float(x) for x in re.findall(match_number, tolerance)][0] * target_value / 100.
                         if tolerance == 0:
                             logger.debug('tolerance zero inacceptable: setting tolerance to 1.')
                             tolerance = 1.
                         logger.debug('testing a-t<b<a+t')
                         if target_value -  tolerance <= value_get and value_get <= target_value + tolerance:
-                            logger.info('the value <{}> get ({}) is included in the target_value ({}) +- tolerance ({})'.format(a_target,value_get,target_value,tolerance))
+                            logger.info('the value <{}> get ({}) is included in the target_value ({}) +- tolerance ({})'.format(a_target, value_get, target_value, tolerance))
                         else:
-                            raise exceptions.DriplineValueError('{} value get ({}) is NOT included in the target_value ({}) +- tolerance ({}): stopping here!'.format(a_target,value_get,target_value,tolerance))
+                            raise exceptions.DriplineValueError('{} value get ({}) is NOT included in the target_value ({}) +- tolerance ({}): stopping here!'.format(a_target, value_get, target_value, tolerance))
                     else:
                         raise exceptions.DriplineValueError('{} tolerance is not a float, int or string: stopping here'.format(a_target))
                 else:
@@ -224,42 +224,42 @@ class MultiDo(Endpoint):
                 target_backup = target_value
                 value_get_backup = value_get
 
-                if value_get=='on' or value_get=='enable' or value_get=='enabled' or value_get == 'positive':
-                    value_get=1
-                elif value_get=='off' or value_get=='disable' or value_get=='disabled' or value_get == 'negative':
-                    value_get=0
+                if value_get == 'on' or value_get == 'enable' or value_get == 'enabled' or value_get == 'positive':
+                    value_get = 1
+                elif value_get == 'off' or value_get == 'disable' or value_get == 'disabled' or value_get == 'negative':
+                    value_get = 0
 
-                if isinstance(target_value,str):
+                if isinstance(target_value, str):
                     # changing target in the dictionary
-                    if target_value=='on' or target_value=='enable' or target_value=='enabled' or target_value == 'positive':
-                        target_value=1
-                    if target_value=='off' or target_value=='disable' or target_value=='disabled' or target_value ==  'negative':
-                        target_value=0
+                    if target_value == 'on' or target_value == 'enable' or target_value == 'enabled' or target_value == 'positive':
+                        target_value = 1
+                    if target_value == 'off' or target_value == 'disable' or target_value == 'disabled' or target_value ==  'negative':
+                        target_value = 0
                     # checking is target and value_get are the same
 
-                if target_value==value_get:
-                    logger.info('value get ({}) corresponds to the target ({}): going on'.format(value_get_backup,target_backup))
+                if target_value == value_get:
+                    logger.info('value get ({}) corresponds to the target ({}): going on'.format(value_get_backup, target_backup))
                 else:
-                    raise exceptions.DriplineValueError('{} value get ({}) DOES NOT correspond to the target_value ({}): stopping here!'.format(a_target,value_get_backup,target_backup))
+                    raise exceptions.DriplineValueError('{} value get ({}) DOES NOT correspond to the target_value ({}): stopping here!'.format(a_target, value_get_backup, target_backup))
 
             # if the value we are checking is a bool
             elif isinstance(value_get, bool):
-                if not isinstance(target_value,bool):
+                if not isinstance(target_value, bool):
                     logger.warning('target_value is not the same type as the value get: going to use the set value ({}) as target_value'.format(value))
                     target_value = value
-                if isinstance(target_value,bool):
-                    if value_get==target_value:
-                        logger.info('value get ({}) corresponds to the target ({}): going on'.format(value_get,target_value))
+                if isinstance(target_value, bool):
+                    if value_get == target_value:
+                        logger.info('value get ({}) corresponds to the target ({}): going on'.format(value_get, target_value))
                     else:
-                        raise exceptions.DriplineValueError('{} value get ({}) DOES NOT correspond to the target ({}): stopping here!'.format(a_target,value_get,target_value))
+                        raise exceptions.DriplineValueError('{} value get ({}) DOES NOT correspond to the target ({}): stopping here!'.format(a_target, value_get, target_value))
                 else:
                     raise exceptions.DriplineValueError('Cannot check! value set and target are not the same type as value get (string): stopping here!')
 
             # if you are in this "else", this means that you either wanted to mess up with us or you are not viligant enough
             else:
-                raise exceptions.DriplineValueError('{} value get ({}) is not a float, int, string, bool, None ({}): SUPER WEIRD!'.format(a_target,value_get,type(value_get)))
+                raise exceptions.DriplineValueError('{} value get ({}) is not a float, int, string, bool, None ({}): SUPER WEIRD!'.format(a_target, value_get, type(value_get)))
 
-            logger.info('{} set to {}'.format(a_target,value_get))
+            logger.info('{} set to {}'.format(a_target, value_get))
 
         return 'set and check successful'
 
@@ -273,7 +273,7 @@ class MultiDo(Endpoint):
         logger.debug('receiving a set_condition {} request'.format(number))
         if number in self._set_condition_dict:
             value = self._set_condition_dict[number]
-            logger.warning('Condition {} reached!  Applying set of {} to {}'.format(number,value,self.name))
+            logger.warning('Condition {} reached!  Applying set of {} to {}'.format(number, value,self.name))
             self.on_set(value)
         else:
             logger.debug('condition {} is unknown: ignoring!'.format(number))
@@ -302,8 +302,8 @@ class MultiSet(MultiDo):
     '''
     def __init__(self, **kwargs):
         for a_target in kwargs['targets']:
-            if 'no_check' in a_target and a_target['no_check']==False:
-                logger.critical("MultiSet forces no_check option for all endpoints.  Option for {} of {} overridden.".format(a_target['target'],kwargs['name']))
+            if 'no_check' in a_target and a_target['no_check'] == False:
+                logger.critical("MultiSet forces no_check option for all endpoints.  Option for {} of {} overridden.".format(a_target['target'], kwargs['name']))
             a_target.update({'no_check':True})
         MultiDo.__init__(self, **kwargs)
 

--- a/dragonfly/implementations/multido.py
+++ b/dragonfly/implementations/multido.py
@@ -5,6 +5,7 @@ Convenience object allowing a single target to interact with multiple endpoints
 from __future__ import absolute_import
 __all__ = []
 
+from time import sleep
 from dripline.core import Endpoint, fancy_doc, exceptions
 
 import logging
@@ -65,7 +66,7 @@ class MultiDo(Endpoint):
             else:
                 these_details.update({'payload_field':'value_cal'})
             if 'units' in a_target and 'formatter' in a_target:
-                raise exceptions.DriplineValueError('may not specify both "units" and "formatter"')
+                raise exceptions.DriplineValueError('{} : {} - may not specify both "units" and "formatter"'.format(self.name,a_target['target']))
             if 'formatter' in a_target:
                 these_details['formatter'] = a_target['formatter']
             elif 'units' in a_target:
@@ -87,6 +88,8 @@ class MultiDo(Endpoint):
                 these_details.update({'get_name':a_target['target']})
             if 'target_value' in a_target:
                 these_details.update({'target_value':a_target['target_value']})
+            if 'delay_check' in a_target:
+                these_details.update({'delay_check':a_target['delay_check']})
             # Differentiate set/get behavior in MultiDo
             if 'get_only' in a_target:
                 these_details.update({'get_only':a_target['get_only']})
@@ -138,6 +141,9 @@ class MultiDo(Endpoint):
                 logger.info('no check after set required: skipping!')
                 continue
             else:
+                if 'delay_check' in details:
+                    logger.debug('sleeping for {} sec'.format(details['delay_check']))
+                    sleep(details['delay_check'])
                 logger.info('checking <{}>'.format(a_target))
                 result = self.provider.get(details['get_name'])
                 value_get = result[details['check_field']]
@@ -162,7 +168,7 @@ class MultiDo(Endpoint):
                 logger.debug('no target_value given: using value ({}) as a target_value to check'.format(value))
                 target_value = value
             if value_get==None:
-                raise exceptions.DriplineValueError('value get is a None')
+                raise exceptions.DriplineValueError('{} value get is None'.format(a_target))
 
             # if the value we are checking is a float/int
             if isinstance(value_get, (int,float)):
@@ -191,7 +197,7 @@ class MultiDo(Endpoint):
                         if target_value -  tolerance <= value_get and value_get <= target_value + tolerance:
                             logger.info('the value get <{}> ({}) is included in the target_value ({}) +- tolerance ({})'.format(a_target,value_get,target_value,tolerance))
                         else:
-                            raise exceptions.DriplineValueError('the value get <{}> ({}) is NOT included in the target_value ({}) +- tolerance ({}): stopping here!'.format(a_target,value_get,target_value,tolerance))
+                            raise exceptions.DriplineValueError('{} value get ({}) is NOT included in the target_value ({}) +- tolerance ({}): stopping here!'.format(a_target,value_get,target_value,tolerance))
                     elif isinstance(tolerance,str):
                         if '%' not in tolerance:
                             logger.debug('absolute tolerance')
@@ -207,11 +213,11 @@ class MultiDo(Endpoint):
                         if target_value -  tolerance <= value_get and value_get <= target_value + tolerance:
                             logger.info('the value <{}> get ({}) is included in the target_value ({}) +- tolerance ({})'.format(a_target,value_get,target_value,tolerance))
                         else:
-                            raise exceptions.DriplineValueError('the value <{}> get ({}) is NOT included in the target_value ({}) +- tolerance ({}): stopping here!'.format(a_target,value_get,target_value,tolerance))
+                            raise exceptions.DriplineValueError('{} value get ({}) is NOT included in the target_value ({}) +- tolerance ({}): stopping here!'.format(a_target,value_get,target_value,tolerance))
                     else:
-                        raise exceptions.DriplineValueError('tolerance is not a float, int or string: stopping here')
+                        raise exceptions.DriplineValueError('{} tolerance is not a float, int or string: stopping here'.format(a_target))
                 else:
-                    raise exceptions.DriplineValueError('Cannot check! value set and target_value are not the same type as value get (float/int): stopping here!')
+                    raise exceptions.DriplineValueError('Cannot check! {} value set and target_value are not the same type as value get (float/int): stopping here!'.format(a_target))
 
             # if the value we are checking is a string
             elif isinstance(value_get, str):
@@ -229,13 +235,12 @@ class MultiDo(Endpoint):
                         target_value=1
                     if target_value=='off' or target_value=='disable' or target_value=='disabled' or target_value ==  'negative':
                         target_value=0
-                    # raise exceptions.DriplineValueError('Cannot check! value set and target_value are not the same type as value get (string): stopping here!')
                     # checking is target and value_get are the same
 
                 if target_value==value_get:
                     logger.info('value get ({}) corresponds to the target ({}): going on'.format(value_get_backup,target_backup))
                 else:
-                    raise exceptions.DriplineValueError('value get ({}) DOES NOT correspond to the target_value ({}): stopping here!'.format(value_get_backup,target_backup))
+                    raise exceptions.DriplineValueError('{} value get ({}) DOES NOT correspond to the target_value ({}): stopping here!'.format(a_target,value_get_backup,target_backup))
 
             # if the value we are checking is a bool
             elif isinstance(value_get, bool):
@@ -246,13 +251,13 @@ class MultiDo(Endpoint):
                     if value_get==target_value:
                         logger.info('value get ({}) corresponds to the target ({}): going on'.format(value_get,target_value))
                     else:
-                        raise exceptions.DriplineValueError('value get ({}) DOES NOT correspond to the target ({}): stopping here!'.format(value_get,target_value))
+                        raise exceptions.DriplineValueError('{} value get ({}) DOES NOT correspond to the target ({}): stopping here!'.format(a_target,value_get,target_value))
                 else:
                     raise exceptions.DriplineValueError('Cannot check! value set and target are not the same type as value get (string): stopping here!')
 
             # if you are in this "else", this means that you either wanted to mess up with us or you are not viligant enough
             else:
-                raise exceptions.DriplineValueError('value get ({}) is not a float, int, string, bool, None ({}): SUPER WEIRD!'.format(value_get,type(value_get)))
+                raise exceptions.DriplineValueError('{} value get ({}) is not a float, int, string, bool, None ({}): SUPER WEIRD!'.format(a_target,value_get,type(value_get)))
 
             logger.info('{} set to {}'.format(a_target,value_get))
 

--- a/dragonfly/implementations/multido.py
+++ b/dragonfly/implementations/multido.py
@@ -167,7 +167,7 @@ class MultiDo(Endpoint):
             else:
                 logger.debug('no target_value given: using value ({}) as a target_value to check'.format(value))
                 target_value = value
-            if value_get==None:
+            if value_get is None:
                 raise exceptions.DriplineValueError('{} value get is None'.format(a_target))
 
             # if the value we are checking is a float/int
@@ -183,7 +183,7 @@ class MultiDo(Endpoint):
                         tolerance = details['tolerance']
                     else:
                         tolerance = None
-                    if tolerance==None:
+                    if tolerance is None:
                         logger.debug('No tolerance given: assigning an arbitrary tolerance (1.)')
                         tolerance = 1.
                     if not isinstance(tolerance,float) and not isinstance(tolerance,int) and not isinstance(tolerance,str):

--- a/dragonfly/implementations/slack_interface.py
+++ b/dragonfly/implementations/slack_interface.py
@@ -87,7 +87,7 @@ class SlackInterface(Gogol):
         self._update_history(routing_info['from'])
         username = routing_info['from']
         if routing_info['level'] not in self._mapping:
-            logger.debug("don't know this level: {}".format(level))
+            logger.debug("don't know this level: {}".format(routing_info['level']))
             return
         if self._is_allowed_to_talk(routing_info['from']):
             if msg.payload == "":


### PR DESCRIPTION
Purpose of this PR is to add a 'delay_check' option to every entry in a MultiDo, which adds a sleep between the set and the check to fix the power supply output bounce.  I also tried to clarify the error messages to make it easier to tell what fails without diving into the logs by saying which endpoint of a multido failed.