### PR TITLE
Feature/remove saved state dependence

### DIFF
--- a/dragonfly/implementations/psyllid_provider.py
+++ b/dragonfly/implementations/psyllid_provider.py
@@ -67,9 +67,9 @@ class PsyllidProvider(core.Provider):
         '''
         Returns mode_dict containing the information which psyllid instance is in triggering or streaming mode
         Stopped psyllid instances are in acquisition mode None
-        Content of mode_dict is not updated at this point
-        Content of mode_dict is updated by calling prepare_daq_system (in roach_daq_run_interface) or check_all_psyllid_instances
         '''
+        for channel in self.channel_dict.keys():
+            self.get_acquisition_mode(channel)
         return self.mode_dict
 
 
@@ -83,6 +83,8 @@ class PsyllidProvider(core.Provider):
         '''
         Returns the number of psyllid instances that are activated
         '''
+        for channel in self.channel_dict.keys():
+            self.request_status(channel)
         active_channels = [i for i in self.status_value_dict.keys() if self.status_value_dict[i]==4]
         return active_channels
 
@@ -132,6 +134,7 @@ class PsyllidProvider(core.Provider):
         '''
         Tells psyllid to activate and checks whether activation was successful
         '''
+        self.request_status(channel)
         if self.status_value_dict[channel] == 0:
             logger.info('Activating Psyllid instance for channel {}'.format(channel))
             self.provider.cmd(self.queue_dict[channel], 'activate-daq')
@@ -149,6 +152,7 @@ class PsyllidProvider(core.Provider):
         '''
         Tells psyllid to deactivate and checks whether deactivation was successful
         '''
+        self.request_status(channel)
         if self.status_value_dict[channel] != 0:
             logger.info('Deactivating Psyllid instance of channel {}'.format(channel))
             self.provider.cmd(self.queue_dict[channel],'deactivate-daq')
@@ -166,6 +170,7 @@ class PsyllidProvider(core.Provider):
         '''
         Tells psyllid to reactivate and checks whether reactivation was successful
         '''
+        self.request_status(channel)
         if self.status_value_dict[channel] == 4:
             logger.info('Reactivating Psyllid instance of channel {}'.format(channel))
             self.provider.cmd(self.queue_dict[channel], 'reactivate-daq')
@@ -210,6 +215,8 @@ class PsyllidProvider(core.Provider):
         '''
         Returns a dictionary with all central frequencies
         '''
+        for channel in self.channel_dict.keys():
+            self.get_central_frequency(channel)
         return self.freq_dict
 
 
@@ -250,7 +257,7 @@ class PsyllidProvider(core.Provider):
         request = '.active-config.{}.{}.center-freq'.format(self.channel_dict[channel], routing_key_map[self.mode_dict[channel]])
         self.provider.set(self.queue_dict[channel]+request, cf)
         logger.info('Set central frequency of {} writer for channel {} to {} Hz'.format(self.mode_dict[channel], channel, cf))
-        self.freq_dict[channel]=cf
+        self.get_central_frequency(channel)
 
 
     def is_psyllid_using_monarch(self, channel):

--- a/dragonfly/implementations/psyllid_provider.py
+++ b/dragonfly/implementations/psyllid_provider.py
@@ -138,13 +138,14 @@ class PsyllidProvider(core.Provider):
         if self.status_value_dict[channel] != 4:
             logger.info('Activating Psyllid instance for channel {}'.format(channel))
             self.provider.cmd(self.queue_dict[channel], 'activate-daq')
+            time.sleep(1)
+            self.request_status(channel)
+            if self.status_value_dict[channel]!=4:
+                logger.error('Activating failed')
+                raise core.exceptions.DriplineGenericDAQError('Activating psyllid failed')
+
         else:
             logger.info('Psyllid instance of channel {} is already activated'.format(channel))
-        time.sleep(1)
-        self.request_status(channel)
-        if self.status_value_dict[channel]!=4:
-            logger.error('Activating failed')
-            raise core.exceptions.DriplineGenericDAQError('Activating psyllid failed')
 
 
     def deactivate(self, channel):
@@ -155,13 +156,14 @@ class PsyllidProvider(core.Provider):
         if self.status_value_dict[channel] != 0:
             logger.info('Deactivating Psyllid instance of channel {}'.format(channel))
             self.provider.cmd(self.queue_dict[channel],'deactivate-daq')
+            time.sleep(1)
+            self.request_status(channel)
+           if self.status_value_dict[channel]!=0:
+              logger.error('Deactivating failed')
+              raise core.exceptions.DriplineGenericDAQError('Deactivating psyllid failed')
+
         else:
             logger.info('Psyllid instance of channel {} is already deactivated'.format(channel))
-        time.sleep(1)
-        self.request_status(channel)
-        if self.status_value_dict[channel]!=0:
-            logger.error('Deactivating failed')
-            raise core.exceptions.DriplineGenericDAQError('Deactivating psyllid failed')
 
 
     def reactivate(self, channel):

--- a/dragonfly/implementations/psyllid_provider.py
+++ b/dragonfly/implementations/psyllid_provider.py
@@ -505,7 +505,7 @@ class PsyllidProvider(core.Provider):
         self.start_run(channel ,1000, self.temp_file)
         time.sleep(1)
 
-        # self.write_trigger_mask(channel, filename)
+        # self._write_trigger_mask(channel, filename)
 
         logger.info('Telling psyllid to use monarch again for next run')
         self.provider.set(self.queue_dict[channel]+'.use-monarch', True)
@@ -519,7 +519,7 @@ class PsyllidProvider(core.Provider):
         self.provider.cmd(self.queue_dict[channel],request)
 
 
-    def write_trigger_mask(self, channel, filename):
+    def _write_trigger_mask(self, channel, filename):
         '''
         Tells psyllid to write a frequency mask to a json file
         '''

--- a/dragonfly/implementations/psyllid_provider.py
+++ b/dragonfly/implementations/psyllid_provider.py
@@ -158,9 +158,9 @@ class PsyllidProvider(core.Provider):
             self.provider.cmd(self.queue_dict[channel],'deactivate-daq')
             time.sleep(1)
             self.request_status(channel)
-           if self.status_value_dict[channel]!=0:
-              logger.error('Deactivating failed')
-              raise core.exceptions.DriplineGenericDAQError('Deactivating psyllid failed')
+            if self.status_value_dict[channel]!=0:
+                logger.error('Deactivating failed')
+                raise core.exceptions.DriplineGenericDAQError('Deactivating psyllid failed')
 
         else:
             logger.info('Psyllid instance of channel {} is already deactivated'.format(channel))


### PR DESCRIPTION
Added request_status, get_central_frequency and get_acquisition_mode wherever this information is used (or returned). Also commented the line, that makes psyllid write the mask on zeppelin, whenever a new mask is recorded.

I have tested the changes using insectarium. Everything I tested worked as expected.

I did not remove the dictionaries, because calling the methods listed above, the content of the dictionaries is updated with the newest state/frequency/mode information before it is used and as a result, that information is always up to date. If you prefer me to invest more work, I could get rid of them entirely, but personally, I don't find it so ugly the way it is now.

About the psyllid starting sequence:
It is not possible to start in deactivated state, followed by applying the trigger settings and then activate psyllid. The reason is, that the fmt settings are active-node settings and the node-bindings are not available when psyllid is not activated. 
I don't think that that is a problem though. If we keep the current starting sequence: start psyllid (activated or deactivated doesn't matter) -> prepare-daq-system (activate if deactivated) -> set_default_trigger (set thresholds & buffer sizes, then reactivate) everything should work, because in every method the psyllid state is  re-requested.

Actually, when psyllid starts-up activated, the order of prepare-daq and set-trigger don't matter.