### PR TITLE
Feature/nfs dung

### DIFF
--- a/dragonfly/implementations/dungbeetle.py
+++ b/dragonfly/implementations/dungbeetle.py
@@ -14,7 +14,7 @@ class DungBeetle(Endpoint,Scheduler):
     '''
     def __init__(self,
                  root_dirs = [],
-                 max_age = {"minutes":3},
+                 max_age = {"hours":2},
                  ignore_dirs = [],
                  warning_interval = 12,
                  **kwargs):

--- a/dragonfly/implementations/dungbeetle.py
+++ b/dragonfly/implementations/dungbeetle.py
@@ -14,7 +14,7 @@ class DungBeetle(Endpoint,Scheduler):
     '''
     def __init__(self,
                  root_dirs = [],
-                 max_age = {"hours":2},
+                 max_age = {"minutes":3},
                  ignore_dirs = [],
                  warning_interval = 12,
                  **kwargs):
@@ -38,14 +38,17 @@ class DungBeetle(Endpoint,Scheduler):
         creation_time = datetime.datetime.fromtimestamp(os.path.getctime(path))
         if creation_time < min_creation_time and (not path in self.ignore_dirs):
             try:
-                os.rm(path)
-                logger.info(" file [{}] has been removed.".format(path))
+                os.remove(path)
+                logger.info("nfs file [{}] has been removed.".format(path))
             except:
                 pass
 
     # recursively delete empty directories
     def del_dir(self, path, min_creation_time, processed_dirs_per_cycle, new_dirs):
-        if os.path.isdir(path):
+        if not os.path.isdir(path):
+            if ".nfs" in path:
+                self.clean_nfs(path, min_creation_time)
+        elif os.path.isdir(path):
             creation_time = datetime.datetime.fromtimestamp(os.path.getctime(path))
             no_sub_dir = True
             for item in os.listdir(path):
@@ -64,8 +67,6 @@ class DungBeetle(Endpoint,Scheduler):
                             new_dirs.append(path)
                         else:
                             self.processed_dirs[path] += 1
-        else if ".nfs" in path: 
-            clean_nfs(path, min_creation_time)
 
     # clean up empty directories under a specific directory without deleting itself
     def clean_dir(self, processed_dirs_per_cycle, new_dirs):

--- a/dragonfly/implementations/dungbeetle.py
+++ b/dragonfly/implementations/dungbeetle.py
@@ -33,6 +33,16 @@ class DungBeetle(Endpoint,Scheduler):
         self.processed_dirs = {}
         self.warning_interval = warning_interval
 
+    # delete old .nfs files that get stranded 
+    def clean_nfs(self, path, min_creation_time):
+        creation_time = datetime.datetime.fromtimestamp(os.path.getctime(path))
+        if creation_time < min_creation_time and (not path in self.ignore_dirs):
+            try:
+                os.rm(path)
+                logger.info(" file [{}] has been removed.".format(path))
+            except:
+                pass
+
     # recursively delete empty directories
     def del_dir(self, path, min_creation_time, processed_dirs_per_cycle, new_dirs):
         if os.path.isdir(path):
@@ -54,6 +64,8 @@ class DungBeetle(Endpoint,Scheduler):
                             new_dirs.append(path)
                         else:
                             self.processed_dirs[path] += 1
+        else if ".nfs" in path: 
+            clean_nfs(path, min_creation_time)
 
     # clean up empty directories under a specific directory without deleting itself
     def clean_dir(self, processed_dirs_per_cycle, new_dirs):

--- a/dragonfly/implementations/dungbeetle.py
+++ b/dragonfly/implementations/dungbeetle.py
@@ -39,7 +39,7 @@ class DungBeetle(Endpoint,Scheduler):
         if creation_time < min_creation_time and (not path in self.ignore_dirs):
             try:
                 os.remove(path)
-                logger.info("nfs file [{}] has been removed.".format(path))
+                logger.warning("nfs file [{}] has been removed.".format(path))
             except OSError:
                 logger.warning("nfs file [{}] was not successfully removed".format(path))
 

--- a/dragonfly/implementations/dungbeetle.py
+++ b/dragonfly/implementations/dungbeetle.py
@@ -40,8 +40,10 @@ class DungBeetle(Endpoint,Scheduler):
             try:
                 os.remove(path)
                 logger.info("nfs file [{}] has been removed.".format(path))
-            except:
-                pass
+            except OSError:
+                logger.warning("nfs file [{}] was not successfully removed".format(path))
+
+                
 
     # recursively delete empty directories
     def del_dir(self, path, min_creation_time, processed_dirs_per_cycle, new_dirs):


### PR DESCRIPTION
Removes .nfs files older than max_age
Tested on local directory, has expected behavior

I piggy-back over the max_age to delete directories, not creating a new user parameter (this may cause excess warnings, when dungbeetle will get around to deleting the bad files on the next cycle, but I haven't been able to reproduce it)