### PR TITLE
Feature/more generic logger

### DIFF
--- a/dragonfly/implementations/postgres_interface.py
+++ b/dragonfly/implementations/postgres_interface.py
@@ -31,10 +31,8 @@ import logging
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
-__all__.append('PostgreSQLInterface')
-__all__.append("SQLTable")
-__all__.append('SQLSnapshot')
 
+__all__.append('PostgreSQLInterface')
 @fancy_doc
 class PostgreSQLInterface(Provider):
     '''
@@ -103,13 +101,15 @@ class PostgreSQLInterface(Provider):
         logger.debug('snapshot sent')
         return
 
-
+__all__.append("SQLTable")
 @fancy_doc
 class SQLTable(Endpoint):
     '''
     A class for making calls to _insert_with_return
     '''
     def __init__(self, table_name, schema,
+                 do_upsert=False,
+                 ignore_keys=[],
                  required_insert_names=[],
                  return_col_names=[],
                  optional_insert_names=[],
@@ -127,6 +127,8 @@ class SQLTable(Endpoint):
         if not 'sqlalchemy' in globals():
             raise ImportError('SQLAlchemy not found, required for SQLTable class')
         Endpoint.__init__(self, *args, **kwargs)
+        self.do_upsert = do_upsert
+        self.ignore_keys = ignore_keys
         self.table = None
         self.table_name = table_name
         self.schema = schema
@@ -178,9 +180,15 @@ class SQLTable(Endpoint):
 
     def _insert_with_return(self, insert_kv_dict, return_col_names_list):
         try:
-            ins = self.table.insert().values(**insert_kv_dict)
+            #ins = self.table.insert().values(**insert_kv_dict)
+            ins = sqlalchemy.dialects.postgresql.insert(self.table).values(**insert_kv_dict)
             if return_col_names_list:
+                logger.debug('adding return clause')
                 ins = ins.returning(*[self.table.c[col_name] for col_name in return_col_names_list])
+            if self.do_upsert:
+                p_keys = [key.name for key in sqlalchemy.inspection.inspect(self.table).primary_key]
+                update_d = {k:v for k,v in insert_kv_dict.items() if not k in p_keys}
+                ins = ins.on_conflict_do_update(index_elements=p_keys, set_=update_d)
             insert_result = ins.execute()
             if return_col_names_list:
                 return_values = insert_result.first()
@@ -215,6 +223,7 @@ class SQLTable(Endpoint):
         return_vals = self._insert_with_return(this_insert, self._return_names,)
         return return_vals
 
+__all__.append('SQLSnapshot')
 @fancy_doc
 class SQLSnapshot(SQLTable):
 

--- a/dragonfly/implementations/sensor_logger.py
+++ b/dragonfly/implementations/sensor_logger.py
@@ -52,9 +52,6 @@ class SensorLogger(Gogol, PostgreSQLInterface):
     def this_consume(self, message, basic_deliver):
         logger.debug("consuming message to: {}".format(basic_deliver.routing_key))
         ### Get the sensor name
-        if not basic_deliver.routing_key.split('.')[0] == self.prefix:
-            logger.warning("should not consume this message")
-            return
         sensor_name = None
         if '.' in basic_deliver.routing_key:
             re_out = re.match(r'{}.(?P<from>\S+)'.format(self.prefix), basic_deliver.routing_key)
@@ -86,8 +83,9 @@ class SensorLogger(Gogol, PostgreSQLInterface):
             insert_data = {'endpoint_name': sensor_name,
                            'timestamp': message['timestamp'],
                           }
-            for key in ['value_raw', 'value_cal', 'memo']:
-                if key in message.payload:
-                    insert_data[key] = message.payload[key]
+            insert_data.update(message.payload)
+            #for key in ['value_raw', 'value_cal', 'memo']:
+            #    if key in message.payload:
+            #        insert_data[key] = message.payload[key]
             this_data_table.do_insert(**insert_data)
             logger.info('value logged for <{}>'.format(sensor_name))


### PR DESCRIPTION
Migrating some changes from ADMX:
## expected behavior fix(es)
- the sensor logger hard codes a requirement of using only specified payload keys, it should be possible to change this (seems better suited in the "table" class). Maybe even better would be an smaller helper method with only the logic for parsing the incoming payload data into an insert dictionary so that we can isolate and override just that logic.

## new feature
- table should support option for an "upsert" (insert or update if missing), we don't (currently) need it for P8, but it is a reasonable feature we may want access to and it is already implemented.