### PR TITLE
attempt at fix dungbeetle alert

### DIFF
--- a/dragonfly/implementations/dungbeetle.py
+++ b/dragonfly/implementations/dungbeetle.py
@@ -48,8 +48,12 @@ class DungBeetle(Endpoint,Scheduler):
     # recursively delete empty directories
     def del_dir(self, path, min_creation_time, processed_dirs_per_cycle, new_dirs):
         if os.path.isfile(path):
-            if ".nfs" in path or os.path.getsize(path) == 0:
-                self.clean_file(path, min_creation_time)
+            try:
+                if ".nfs" in path or os.path.getsize(path) == 0:
+                    self.clean_file(path, min_creation_time)
+            except OSError:
+                if os.path.exists(path):
+                    logger.warning("file [{}] has not been removed.".format(path))
         elif os.path.isdir(path):
             creation_time = datetime.datetime.fromtimestamp(os.path.getctime(path))
             no_sub_dir = True

--- a/dragonfly/implementations/dungbeetle.py
+++ b/dragonfly/implementations/dungbeetle.py
@@ -47,7 +47,7 @@ class DungBeetle(Endpoint,Scheduler):
 
     # recursively delete empty directories
     def del_dir(self, path, min_creation_time, processed_dirs_per_cycle, new_dirs):
-        if not os.path.isdir(path):
+        if os.path.isfile(path):
             if ".nfs" in path or os.path.getsize(path) == 0:
                 self.clean_file(path, min_creation_time)
         elif os.path.isdir(path):


### PR DESCRIPTION
Right now untested. The errors seem to suggest that this is totally coming from the `getsize()` call which only happens here. When it acts on a file that does not exist, it throws this error.

This should be fixed by this change, as `isfile(x)` is not logically the same as `not isdir(x)`. While they are the same statements if I put x = filename or directory name (true, false respectively), when the file does not exist, the statements are not the same. We now check explicitly that this is a real file

Resolves #212 