### PR TITLE
Feature/chiller integration

### DIFF
--- a/dripline/extensions/__init__.py
+++ b/dripline/extensions/__init__.py
@@ -6,4 +6,7 @@ __path__ = __import__('pkgutil').extend_path(__path__, __name__)
 from . import jitter
 
 # Modules in this directory
+
 from .add_auth_spec import *
+from .thermo_fisher_endpoint import *
+from .ethernet_thermo_fisher_service import *

--- a/dripline/extensions/ethernet_thermo_fisher_service.py
+++ b/dripline/extensions/ethernet_thermo_fisher_service.py
@@ -1,0 +1,149 @@
+import re
+import socket
+import threading
+import time
+
+from dripline.core import Service, ThrowReply
+
+import logging
+logger = logging.getLogger(__name__)
+
+__all__ = []
+
+
+__all__.append('EthernetThermoFisherService')
+class EthernetThermoFisherService(Service):
+    '''
+    A fairly specific subclass of Service for connecting to ethernet-capable thermo fisher devices.
+    In particular, devices must support a half-duplex serial communication with header information, variable length data-payload and a checksum.
+    '''
+    def __init__(self,
+                 socket_timeout=10,
+                 socket_info=('localhost', 1234),
+                 lead_char = b'\xcc',
+                 msb = b'\x00',
+                 lsb = b'\x01',
+                 **kwargs
+                 ):
+        '''
+        Args:
+            socket_timeout (int): number of seconds to wait for a reply from the device before timeout.
+            socket_info (tuple or string): either socket.socket.connect argument tuple, or string that
+                parses into one.
+        '''
+        Service.__init__(self, **kwargs)
+
+        if isinstance(socket_info, str):
+            logger.debug(f"Formatting socket_info: {socket_info}")
+            re_str = "\([\"'](\S+)[\"'], ?(\d+)\)"
+            (ip,port) = re.findall(re_str,socket_info)[0]
+            socket_info = (ip,int(port))
+
+        self.alock = threading.Lock()
+        self.socket = socket.socket()
+        self.socket_timeout = float(socket_timeout)
+        self.socket_info = socket_info
+        self.lead_char = lead_char
+        self.msb = msb
+        self.lsb = lsb
+
+    def send_to_device(self, commands, **kwargs):
+        '''
+        Standard device access method to communicate with instrument.
+        NEVER RENAME THIS METHOD!
+
+        commands (list||None): list of command(s) to send to the instrument following (re)connection to the instrument, still must return a reply!
+                             : if impossible, set as None to skip
+        '''
+        if isinstance(commands, str):
+            commands = [commands]
+        self.alock.acquire()
+
+        try:
+            data = self._send_commands(commands)
+        except Exception as err:
+            logger.critical(str(err))
+            try:
+                data = self._send_commands(commands)
+                logger.critical("Query successful after ethernet connection recovered")
+            except socket.error as err: # simply trying to make it possible to catch the error below
+                logger.warning(f"socket.error <{err}> received, attempting reconnect")
+                logger.critical("Ethernet reconnect failed, dead socket")
+                raise ThrowReply('resource_error_connection', "Broken ethernet socket")
+            except Exception as err: ##TODO handle all exceptions, that seems questionable
+                logger.critical("Query failed after successful ethernet socket reconnect")
+                raise ThrowReply('resource_error_no_response', str(err))
+        finally:
+            self.alock.release()
+        to_return = ';'.join(data)
+        logger.debug(f"should return:\n{to_return}")
+        return to_return
+
+    def calculate_checksum(self, command_bytes):
+        """
+        Calculate the checksum by:
+        1. Summing the bytes.
+        2. Taking the lower 8 bits (1-byte sum).
+        3. Performing bitwise XOR with 0xFF.
+        """
+        byte_sum = sum(command_bytes) & 0xFF  # Sum and reduce to 1 byte
+        checksum = byte_sum ^ 0xFF            # Bitwise inversion
+        return checksum
+    
+    def check_checksum(self, cmd):
+        # calculate checksum of response except lead_char and checksum and check if match checksum
+        return self.calculate_checksum( cmd[1:-1] ) == cmd[-1]
+
+
+    def _send_commands(self, commands):
+        '''
+        Take a list of commands, send to instrument and receive responses, do any necessary formatting.
+
+        commands (list||None): list of command(s) to send to the instrument following (re)connection to the instrument, still must return a reply!
+                             : if impossible, set as None to skip
+        '''
+        all_data=[]
+
+        for command in commands:
+            logger.debug(f"Assemblind cmd")
+            command = self.msb + self.lsb + command
+            logger.debug(f"Command is {command} or tpye {type(command)}")
+            cs = self.calculate_checksum(command).to_bytes(1, byteorder='big')
+            logger.debug(f"Checksum is {cs} of type {type(cs)}")
+            command = self.lead_char + command + cs
+            
+            issue = True
+            try:
+                self.socket.close()
+                self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM, )
+                self.socket.settimeout(self.socket_timeout)
+                self.socket.connect(self.socket_info)
+                logger.debug(f"Socket: {self.socket}")
+
+                logger.debug(f"sending: {command}")
+                self.socket.send(command)
+                logger.debug("Wait for responds")
+                time.sleep(0.6)
+                logger.debug("Read header")
+                header = self.socket.recv(5)
+                nBytes = int(header[-1])
+                logger.debug("Read data")
+                data = self.socket.recv(nBytes)
+                logger.debug("Read checksum")
+                check = self.socket.recv(1)
+                response = header + data + check
+                issue = False
+            except Exception as err:
+                logger.warning(f"While socket communication we recived an error: {err}")
+            finally:
+                self.socket.close()
+                logger.debug("Closed connection")
+            if issue:
+                raise ThrowReply("connection_error", "No connection to device")
+            logger.info(f"Recived: {response}")
+            if not self.check_checksum(response):
+                raise ThrowReply("checksum_error", "Message has invalid checksum")
+
+            logger.info(f"sync: {repr(command)} -> {repr(data)}")
+            all_data.append(data.hex())
+        return all_data

--- a/dripline/extensions/ethernet_thermo_fisher_service.py
+++ b/dripline/extensions/ethernet_thermo_fisher_service.py
@@ -30,32 +30,29 @@ class EthernetThermoFisherService(EthernetSCPIService):
     A fairly specific subclass of Service for connecting to ethernet-capable thermo fisher devices.
     In particular, devices must support a half-duplex serial communication with header information, variable length data-payload and a checksum.
     '''
-    def __init__(self,
-                 socket_timeout=10,
-                 socket_info=('localhost', 1234),
-                 lead_char = b'\xcc',
-                 msb = b'\x00',
-                 lsb = b'\x01',
-                 **kwargs
-                 ):
+    def __init__(self, **kwargs):
         '''
         Args:
             socket_timeout (int): number of seconds to wait for a reply from the device before timeout.
             socket_info (tuple or string): either socket.socket.connect argument tuple, or string that
                 parses into one.
         '''
-        self.lead_char = lead_char
-        self.msb = msb
-        self.lsb = lsb
-        EthernetSCPIService.__init__(self, 
-                                     socket_timeout=socket_timeout,
-                                     socket_info=socket_info,
-                                     cmd_at_reconnect=["00"],
-                                     reconnect_test="0001",
-                                     command_terminator='',
-                                     response_terminator='ignored',
-                                     reply_echo_cmd=False, 
-                                     **kwargs)
+        self.lead_char = kwargs.pop("lead_char", b'\xcc')
+        self.msb = kwargs.pop("msb", b'\x00')
+        self.lsb = kwargs.pop("lsb", b'\x01')
+ 
+        if 'cmd_at_reconnect' not in kwargs:
+            kwargs['cmd_at_reconnect'] = ['00']
+        if 'reconnect_test' not in kwargs:
+            kwargs['reconnect_test'] = '0001'
+        if 'command_terminator' not in kwargs:
+            kwargs['command_terminator'] = ''
+        if 'response_terminator' not in kwargs:
+            kwargs['response_terminator'] = 'ignored'
+        if 'reply_echo_cmd' not in kwargs:
+            kwargs['reply_echo_cmd'] = False
+
+        EthernetSCPIService.__init__(self, **kwargs)
 
     def calculate_checksum(self, command_bytes):
         """

--- a/dripline/extensions/ethernet_thermo_fisher_service.py
+++ b/dripline/extensions/ethernet_thermo_fisher_service.py
@@ -98,7 +98,13 @@ class EthernetThermoFisherService(EthernetSCPIService):
             logger.debug(f"sending: {cmd}")
             self.socket.send(cmd)
             logger.debug("Wait for responds")
-            time.sleep(0.6)
+            # The device may need some time to reply to the send command.
+            # Currently we are using a sleep to make sure the device has enough time to reply.
+            # This may not be ideal. An example on how to do it with a for loop,
+            # that waits for a message of length N can be found here.
+            # https://docs.python.org/2/howto/sockets.html#socket-howto
+            # This is an enhancement for the future but currently can not be tested.
+            time.sleep(0.1)
             logger.debug("Read header")
             header = self.socket.recv(5)
             nBytes = int(header[-1])

--- a/dripline/extensions/thermo_fisher_endpoint.py
+++ b/dripline/extensions/thermo_fisher_endpoint.py
@@ -1,0 +1,64 @@
+from dripline.core import Entity, calibrate, ThrowReply
+
+import logging
+logger = logging.getLogger(__name__)
+
+__all__ = []
+__all__.append("ThermoFisherGetEntity")
+class ThermoFisherGetEntity(Entity):
+    '''
+    A simple endpoint which stores a value but returns that value + a random offset
+    '''
+
+    units = {0: "",
+             1: "degC",
+             2: "degF",
+             3: "L/min",
+             4: "gal/min",
+             5: "sec",
+             6: "PSI",
+             7: "bar",
+             8: "MOhm cm",
+             9: "%",
+             10: "V",
+             11: "kPa",
+            }
+
+    def __init__(self, 
+                 get_str=None,
+                 **kwargs):
+        '''
+        Args:
+        '''
+        if get_str is None:
+            raise ValueError('<base_str is required to __init__ ThermoFisherGetEntity instance')
+        else:
+            self.cmd_str = get_str
+        Entity.__init__(self, **kwargs)
+
+    @calibrate()
+    def on_get(self):
+        # setup cmd here
+        logger.debug(f'raw cmd string is {self.cmd_str}')
+        logger.debug(f'type cmd is {type(self.cmd_str.encode())}')
+        logger.debug(f"type of {b'\x00'} is {type(b'\x00')}")
+        to_send = [self.cmd_str.encode() + b'\x00']
+        result = self.service.send_to_device(to_send)
+        logger.debug(f'raw result is: {result}')
+
+        # do something here
+        decimal = 10.**(-int(result[0], 16))
+        unit = self.units[int(result[1], 16)]
+        value = float(int(result[2:], 16))
+
+        #result = "%f %s"%(value*decimal, unit)
+        result = value*decimal
+
+        return result
+
+    def on_set(self, value):
+        to_send = [cmd]
+        result = self.service.send_to_device(to_send)
+        logger.debug(f'raw result is: {result}')
+        # do something here
+        return result

--- a/dripline/extensions/thermo_fisher_endpoint.py
+++ b/dripline/extensions/thermo_fisher_endpoint.py
@@ -29,6 +29,7 @@ class ThermoFisherGetEntity(Entity):
                  **kwargs):
         '''
         Args:
+            cmd_str: hexstring of the command, e.g. 20 
         '''
         if get_str is None:
             raise ValueError('<base_str is required to __init__ ThermoFisherGetEntity instance')

--- a/dripline/extensions/thermo_fisher_endpoint.py
+++ b/dripline/extensions/thermo_fisher_endpoint.py
@@ -39,10 +39,9 @@ class ThermoFisherGetEntity(Entity):
     @calibrate()
     def on_get(self):
         # setup cmd here
-        logger.debug(f'raw cmd string is {self.cmd_str}')
-        logger.debug(f'type cmd is {type(self.cmd_str.encode())}')
-        logger.debug(f"type of {b'\x00'} is {type(b'\x00')}")
-        to_send = [self.cmd_str.encode() + b'\x00']
+        logger.debug(f'raw cmd string is {str(self.cmd_str)}')
+        to_send = [bytes.fromhex(str(self.cmd_str)) + b'\x00']
+        logger.debug(f'Send cmd in hex: {to_send[0].hex()}')
         result = self.service.send_to_device(to_send)
         logger.debug(f'raw result is: {result}')
 
@@ -56,7 +55,8 @@ class ThermoFisherGetEntity(Entity):
 
         return result
 
-    def on_set(self, value):
+    def on_set(self, value):       
+        raise ThrowReply('message_error_invalid_method', f"endpoint '{self.name}' does not support set")
         to_send = [cmd]
         result = self.service.send_to_device(to_send)
         logger.debug(f'raw result is: {result}')

--- a/dripline/extensions/thermo_fisher_endpoint.py
+++ b/dripline/extensions/thermo_fisher_endpoint.py
@@ -18,10 +18,10 @@ class ThermoFisherHexGetEntity(Entity):
                  **kwargs):
         '''
         Args:
-            get_str: hexstring of the command, e.g. 20 
+            get_str: hexstring of the command, e.g. 20
         '''
         if get_str is None:
-            raise ValueError('<base_str is required to __init__ ThermoFisherGetEntity instance')
+            raise ValueError('<get_str is required to __init__ ThermoFisherHexGetEntity instance')
         else:
             self.cmd_str = str(get_str).zfill(2)
         Entity.__init__(self, **kwargs)
@@ -41,6 +41,9 @@ class ThermoFisherHexGetEntity(Entity):
 
 
 class ThermoFisherNumericGetEntity(ThermoFisherHexGetEntity):
+    '''
+    A endpoint of a thermo fisher device that returns the request result as a numerica value
+    '''
 
     units = {0: "",
              1: "degC",
@@ -57,6 +60,10 @@ class ThermoFisherNumericGetEntity(ThermoFisherHexGetEntity):
             }
 
     def __init__(self, **kwargs):
+        '''
+        Args:
+            get_str: hexstring of the command, e.g. 20
+        '''
         ThermoFisherHexGetEntity.__init__(self, **kwargs)
 
     @calibrate()

--- a/dripline/extensions/thermo_fisher_endpoint.py
+++ b/dripline/extensions/thermo_fisher_endpoint.py
@@ -4,13 +4,13 @@ import logging
 logger = logging.getLogger(__name__)
 
 __all__ = []
-__all__.append("ThermoFisherGetHexEntity")
-__all__.append("ThermoFisherGetEntity")
+__all__.append("ThermoFisherHexGetEntity")
+__all__.append("ThermoFisherNumericGetEntity")
 
 
-class ThermoFisherGetHexEntity(Entity):
+class ThermoFisherHexGetEntity(Entity):
     '''
-    A simple endpoint which stores a value but returns that value + a random offset
+    A endpoint of a thermo fisher device that returns the request result as a hex-string
     '''
 
     def __init__(self, 
@@ -18,7 +18,7 @@ class ThermoFisherGetHexEntity(Entity):
                  **kwargs):
         '''
         Args:
-            cmd_str: hexstring of the command, e.g. 20 
+            get_str: hexstring of the command, e.g. 20 
         '''
         if get_str is None:
             raise ValueError('<base_str is required to __init__ ThermoFisherGetEntity instance')
@@ -38,14 +38,9 @@ class ThermoFisherGetHexEntity(Entity):
 
     def on_set(self, value):       
         raise ThrowReply('message_error_invalid_method', f"endpoint '{self.name}' does not support set")
-        to_send = [cmd]
-        result = self.service.send_to_device(to_send)
-        logger.debug(f'raw result is: {result}')
-        # do something here
-        return result
 
 
-class ThermoFisherGetEntity(ThermoFisherGetHexEntity):
+class ThermoFisherNumericGetEntity(ThermoFisherHexGetEntity):
 
     units = {0: "",
              1: "degC",
@@ -62,7 +57,7 @@ class ThermoFisherGetEntity(ThermoFisherGetHexEntity):
             }
 
     def __init__(self, **kwargs):
-        ThermoFisherGetHexEntity.__init__(self, **kwargs)
+        ThermoFisherHexGetEntity.__init__(self, **kwargs)
 
     @calibrate()
     def on_get(self):

--- a/dripline/extensions/thermo_fisher_endpoint.py
+++ b/dripline/extensions/thermo_fisher_endpoint.py
@@ -39,9 +39,8 @@ class ThermoFisherGetEntity(Entity):
     @calibrate()
     def on_get(self):
         # setup cmd here
-        logger.debug(f'raw cmd string is {str(self.cmd_str)}')
-        to_send = [bytes.fromhex(str(self.cmd_str)) + b'\x00']
-        logger.debug(f'Send cmd in hex: {to_send[0].hex()}')
+        to_send = [str(self.cmd_str)]
+        logger.debug(f'Send cmd in hexstr: {to_send[0]}')
         result = self.service.send_to_device(to_send)
         logger.debug(f'raw result is: {result}')
 


### PR DESCRIPTION
Our chiller speaks some very special protocal, thus we implement speciallized Service and Entities. 
The following classes are implemented
* EthernetThermoFisherService
* ThermoFisherGetHexEntity
* ThermoFisherGetEntity

**EthernetThermoFisherService** implements the communication protocol with the device. 
A message consists of a header + command + number of data bytes + data bytes + checksum as indicated in this image from the manual 
![image](https://github.com/user-attachments/assets/aedc9605-7d11-446a-9df3-e2a3bb65f538)
The Service takes care of the lead_character, the lsb and msb address as well as byte counting and checksum calculation.
The communication is a half-duplex communication via a serial socket. The answer message follows the same structure as the request message where the command is repeated but the data bytes may be different. The resulting message is striped to data bytes and results are returned as hex-strings.

**ThermoFisherGetHexEntity** implements a get method. A cmd_str is interpreted as hex string. Some formating is needed since depending on the value the config file passes ints or strings. The resulting data from the device are send as hex-string. This entity can be used e.g. for status checking since the status is encoded in a bit-pattern. 

**ThermoFisherGetEntity** implements a get method that returns a numeric value. All get commands on the thermo fisher device return three bytes, represented as hex-string. The first byte encodes the unit and a decimal qualifier. The second and third bytes represent a 2byte int. The resulting final value then is value*decimal qualifier in encoded units. The ThermoFisherGetEntity only returns the numeric value without returning the unit, however a lookup table is used on the fly.