### PR TITLE
CommandEntity and FormatEntity with asteval supports

### DIFF
--- a/dripline/extensions/__init__.py
+++ b/dripline/extensions/__init__.py
@@ -7,3 +7,4 @@ from . import jitter
 
 # Modules in this directory
 from .add_auth_spec import *
+from .asteval_endpoint import *

--- a/dripline/extensions/asteval_endpoint.py
+++ b/dripline/extensions/asteval_endpoint.py
@@ -1,0 +1,75 @@
+import asteval # used for FormatEntity
+import re # used for FormatEntity
+
+from dripline.core import calibrate, ThrowReply
+from dripline.implementations import FormatEntity
+from dripline.core import Entity
+
+import logging
+logger = logging.getLogger(__name__)
+
+__all__ = []
+
+
+
+__all__.append('FormatEntityAsteval')
+class FormatEntityAsteval(FormatEntity):
+    '''
+    Utility Entity allowing arbitrary set and query syntax and formatting for more complicated usage cases
+    No assumption about SCPI communication syntax.
+    '''
+
+    def __init__(self,
+                 asteval_get_string="def f(response): return response",
+                 **kwargs):
+        '''
+        Args:
+            get_str (str): sent verbatim in the event of on_get; if None, getting of endpoint is disabled
+            get_reply_float (bool): apply special formatting to get return
+            set_str (str): sent as set_str.format(value) in the event of on_set; if None, setting of endpoint is disabled
+            set_value_lowercase (bool): default option to map all string set value to .lower()
+                **WARNING**: never set to False if using a set_value_map dict
+            set_value_map (str||dict): inverse of calibration to map raw set value to value sent; either a dictionary or an asteval-interpretable string
+            extract_raw_regex (str): regular expression search pattern applied to get return. Must be constructed with an extraction group keyed with the name "value_raw" (ie r'(?P<value_raw>)' ) 
+        '''
+        super().__init__(**kwargs)
+        self.asteval_get_string = asteval_get_string # has to contain a definition "def f(response): ... return value"
+        logger.debug(f'asteval_get_string: {repr(self.asteval_get_string)}')
+        self.evaluator(asteval_get_string)
+
+    @calibrate()
+    def on_get(self):
+        if self._get_str is None:
+            raise ThrowReply('message_error_invalid_method', f"endpoint '{self.name}' does not support get")
+        result = self.service.send_to_device([self._get_str])
+        logger.debug(f'result is: {result}')
+        if self._extract_raw_regex is not None:
+            first_result = result
+            matches = re.search(self._extract_raw_regex, first_result)
+            if matches is None:
+                logger.error('matching returned none')
+                # exceptions.DriplineValueError
+                raise ThrowReply('resource_error', 'device returned unparsable result, [{}] has no match to input regex [{}]'.format(first_result, self._extract_raw_regex))
+            logger.debug(f"matches are: {matches.groupdict()}")
+            result = matches.groupdict()['value_raw']
+        
+        result = result.replace('\x00', '')
+
+        processed_result = self.evaluator(f"f('{result}')")
+        logger.debug(f"processed_result: {repr(processed_result)}")
+        return processed_result
+
+
+
+__all__.append('CmdEntity')
+class CmdEntity(Entity):
+    def __init__(self, cmd_str=None, **kwargs):
+        Entity.__init__(self, **kwargs)
+        logger.debug(f"I get cmd_str: {cmd_str}, which is of type {type(cmd_str)}.")
+        self.cmd_str = cmd_str
+
+    def cmd(self):
+        logger.debug("Command function was successfully called")
+        if self.cmd_str is None:
+            raise ThrowReply('service_error', f"endpoint '{self.name}' does not support cmd")
+        return self.service.send_to_device([self.cmd_str])


### PR DESCRIPTION
We created two new endpoint entities
* CmdEntity can execute a command, e.g. degaussing of a pressure gauge. This is differentent from get and set
* FormatEntityAsteval which allows for a function to be defined in the config file that is used to convert the response (similar to calibration but more focussed on formating the response"

The Entities are used within the MATS setup for some time and seem to work fine.