### PR TITLE
Run State Service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG img_user=ghcr.io/driplineorg
 ARG img_repo=dripline-python
-ARG img_tag=develop-dev
+ARG img_tag=v5.1.0
 
 FROM ${img_user}/${img_repo}:${img_tag}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 ARG img_user=ghcr.io/driplineorg
 ARG img_repo=dripline-python
-#ARG img_tag=develop-dev
-ARG img_tag=receiver-test
+ARG img_tag=develop-dev
 
 FROM ${img_user}/${img_repo}:${img_tag}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG img_user=ghcr.io/driplineorg
 ARG img_repo=dripline-python
-ARG img_tag=v5.1.2
+ARG img_tag=v5.1.5
 
 FROM ${img_user}/${img_repo}:${img_tag}
 

--- a/dripline/extensions/__init__.py
+++ b/dripline/extensions/__init__.py
@@ -10,3 +10,4 @@ from . import jitter
 from .add_auth_spec import *
 from .thermo_fisher_endpoint import *
 from .ethernet_thermo_fisher_service import *
+from .run_state import *

--- a/dripline/extensions/run_state.py
+++ b/dripline/extensions/run_state.py
@@ -1,0 +1,68 @@
+import threading
+import os
+import json
+from dripline.core import Service, ThrowReply, Entity
+
+import logging
+logger = logging.getLogger(__name__)
+
+__all__ = []
+
+__all__.append('StateGetEntity')
+class StateGetEntity(Entity):
+    def __init__(self, key, **kwargs):
+        self.key = key
+        Entity.__init__(self, **kwargs)
+    
+    def on_get(self):
+        return self.service.get_state()[key]
+
+    def on_set(self, value):
+        raise ThrowReply("on_set_error", f"on_set not available for {self.name}")
+
+
+__all__.append('RunStateService')
+class RunStateService(Service):
+    '''
+    A service providing information about the current run status.
+    '''
+    def __init__(self,
+                 state_file=None,
+                 **kwargs
+                 ):
+        '''
+        Args:
+            state_file (str): File that is used to store the current run state
+        '''
+        Service.__init__(self, **kwargs)
+
+        if state_file is None or not isinstance(state_file, str):
+            raise ThrowReply('service_error_invalid_value', f"Invalid state file: <{state_file}>! Expect string")
+
+        self.alock = threading.Lock()
+        self.state_file
+        
+    def get_state(self):
+        '''
+        Read the state of the run from a file.
+        '''
+        logger.info(f"Ethernet socket {self.socket_info} established")
+        self.alock.acquire()
+        try:
+            if os.path.exists(self.state_file):
+                with open(self.state_file, "r") as open_file:
+                    state = json.load(open_file)
+            else:
+                state = {"run_number": 1,
+                         "run_comment": "Initial run",
+                         "run_active": False}
+        except Exception as err:
+            logger.critical("")
+        finally:
+            self.alock.release()
+        return state
+
+    def save_state(self):
+        with open(self.state_file, "w") as open_file:
+            json.dump(state, open_file)
+        return

--- a/dripline/extensions/run_state.py
+++ b/dripline/extensions/run_state.py
@@ -10,7 +10,16 @@ __all__ = []
 
 __all__.append('StateGetEntity')
 class StateGetEntity(Entity):
+    """
+    Simple Entity to get the state information of the RunStateService.
+    While the information are stored in RunStateService itself, this entity can excess the information from the information dict by `key`.
+    """
+
     def __init__(self, key, **kwargs):
+        """
+        Args:
+        * key (str): key of the information from the state dictionary
+        """
         self.key = key
         Entity.__init__(self, **kwargs)
     
@@ -24,7 +33,8 @@ class StateGetEntity(Entity):
 __all__.append('RunStateService')
 class RunStateService(Service):
     '''
-    A service providing information about the current run status.
+    A service providing information about the current run status. Information are stored in a state dict.
+    Two functions `start_run` and `stop_run` are available. start_run takes a run comment (str) as argument which should describe the current run.
     '''
     def __init__(self,
                  state_file=None,
@@ -63,11 +73,17 @@ class RunStateService(Service):
         return state
 
     def save_state(self, state):
+        '''
+        Save the state of the run to a file.
+        '''
         with open(self.state_file, "w") as open_file:
             json.dump(state, open_file)
         return
 
     def stop_run(self):
+        '''
+        Sets the state of the run to "inactive" and returns the run number of the stopped run.
+        '''
         state = self.get_state()
         if not state["run_active"]:
             logger.info("There is no run to stop")
@@ -78,6 +94,10 @@ class RunStateService(Service):
         return state["run_number"]
 
     def start_run(self, comment):
+        ''' 
+        Starts a new run by increasing the run number by 1, setting a new run comment and changing the state to "active".
+        If a run is still ongoing, it will be stopped first.
+        '''
         logger.info(f"Starting run with comment {comment}")
         state = self.get_state()
         if state["run_active"]:

--- a/dripline/extensions/run_state.py
+++ b/dripline/extensions/run_state.py
@@ -1,9 +1,9 @@
 import threading
 import os
 import json
-from dripline.core import Service, ThrowReply, Entity
-
+from dripline.core import Service, ThrowReply, Entity, MsgAlert
 import logging
+import scarab
 logger = logging.getLogger(__name__)
 
 __all__ = []
@@ -15,7 +15,7 @@ class StateGetEntity(Entity):
         Entity.__init__(self, **kwargs)
     
     def on_get(self):
-        return self.service.get_state()[key]
+        return self.service.get_state()[self.key]
 
     def on_set(self, value):
         raise ThrowReply("on_set_error", f"on_set not available for {self.name}")
@@ -40,13 +40,13 @@ class RunStateService(Service):
             raise ThrowReply('service_error_invalid_value', f"Invalid state file: <{state_file}>! Expect string")
 
         self.alock = threading.Lock()
-        self.state_file
+        self.state_file = state_file
         
     def get_state(self):
         '''
         Read the state of the run from a file.
         '''
-        logger.info(f"Ethernet socket {self.socket_info} established")
+        logger.info(f"reading state")
         self.alock.acquire()
         try:
             if os.path.exists(self.state_file):
@@ -62,7 +62,36 @@ class RunStateService(Service):
             self.alock.release()
         return state
 
-    def save_state(self):
+    def save_state(self, state):
         with open(self.state_file, "w") as open_file:
             json.dump(state, open_file)
         return
+
+    def stop_run(self):
+        state = self.get_state()
+        if not state["run_active"]:
+            logger.info("There is no run to stop")
+        else:
+            state["run_active"] = False
+            self.save_state(state)
+            logger.info(f'Stopped run {state["run_number"]}')
+        return state["run_number"]
+
+    def start_run(self, comment):
+        logger.info(f"Starting run with comment {comment}")
+        state = self.get_state()
+        if state["run_active"]:
+            self.stop_run()
+            
+        state["run_number"] = state["run_number"]+1
+        state["run_comment"] = comment
+        state["run_active"] = True
+        self.save_state(state)
+        the_alert = MsgAlert.create(payload=scarab.to_param(state["run_number"]), routing_key=f'sensor_value.run_number')
+        alert_sent = self.send(the_alert)
+        the_alert = MsgAlert.create(payload=scarab.to_param(state["run_comment"]), routing_key=f'sensor_value.run_comment')
+        alert_sent = self.send(the_alert)
+        the_alert = MsgAlert.create(payload=scarab.to_param(state["run_active"]), routing_key=f'sensor_value.run_active')
+        alert_sent = self.send(the_alert)
+        logger.info(f'Started run {state["run_number"]} with comment: {state["run_comment"]}')
+        return state["run_number"]

--- a/dripline/extensions/run_state.py
+++ b/dripline/extensions/run_state.py
@@ -91,6 +91,8 @@ class RunStateService(Service):
             state["run_active"] = False
             self.save_state(state)
             logger.info(f'Stopped run {state["run_number"]}')
+        the_alert = MsgAlert.create(payload=scarab.to_param({"value_raw": int(state["run_active"])}), routing_key=f'sensor_value.run_active')
+        alert_sent = self.send(the_alert)
         return state["run_number"]
 
     def start_run(self, comment):
@@ -107,11 +109,11 @@ class RunStateService(Service):
         state["run_comment"] = comment
         state["run_active"] = True
         self.save_state(state)
-        the_alert = MsgAlert.create(payload=scarab.to_param(state["run_number"]), routing_key=f'sensor_value.run_number')
+        the_alert = MsgAlert.create(payload=scarab.to_param({"value_raw": state["run_number"]}), routing_key=f'sensor_value.run_number')
         alert_sent = self.send(the_alert)
-        the_alert = MsgAlert.create(payload=scarab.to_param(state["run_comment"]), routing_key=f'sensor_value.run_comment')
+        the_alert = MsgAlert.create(payload=scarab.to_param({"value_raw": state["run_comment"]}), routing_key=f'sensor_value.run_comment')
         alert_sent = self.send(the_alert)
-        the_alert = MsgAlert.create(payload=scarab.to_param(state["run_active"]), routing_key=f'sensor_value.run_active')
+        the_alert = MsgAlert.create(payload=scarab.to_param({"value_raw": int(state["run_active"])}), routing_key=f'sensor_value.run_active')
         alert_sent = self.send(the_alert)
         logger.info(f'Started run {state["run_number"]} with comment: {state["run_comment"]}')
         return state["run_number"]

--- a/examples/run_state.yaml
+++ b/examples/run_state.yaml
@@ -1,0 +1,16 @@
+name: run_state
+module: RunStateService
+state_file: ./state.json
+dripline_mesh:
+  broker: rabbit-broker
+  broker_port: 5672
+endpoints:
+  - name: run_number
+    module: StateGetEntity
+    key: run_number
+  - name: run_comment
+    module: StateGetEntity
+    key: run_comment
+  - name: run_is_active
+    module: StateGetEntity
+    key: run_active


### PR DESCRIPTION
Purpose: While operation several scripts and running conditions are set. Usually we keep track of the settings, scripts etc in an ELOG. However figuring out the exact start and end of such a script from an ELOG and the database can be difficult. 
Therefore we implement a run state service. 
The run state is defined by

- run number: a unique increasing number
- run comment: a user defined comment that describes the purpose of the run
- run is active: a boolean showing if a run is currently on-going.

In a setup with multiple user it is important that not two users run a run script concurrently. Therefore, the run is active variable can indicate if a script is already running and if it is okay to start a new run.

The RunStateService containing a state dict with these three properties. The state is saved locally in a file to continue even if the container goes down. 

Runs can e.g. be started with the dl-agent and returns the run number of the started run.
`dl-agent -b rabbit-broker cmd run_state -s start_run "Test Run"`
The run can be stopped with the dl-agent and returns the run number of the stopped run.
`dl-agent -b rabbit-broker cmd run_state -s stop_run`

Endpoints can be defined to get the individual parameters of the state dict via the StateGetEntity.

An example config file for the service is attached.
This service is especially good to use in python scripts using the dripline.core.interface